### PR TITLE
Fixing Broken Tables and Adding Missing Table Columns (Java Docs)

### DIFF
--- a/docs/java/java_sdk.rst
+++ b/docs/java/java_sdk.rst
@@ -432,27 +432,50 @@ ThreatConnect API. It covers all available resources exposed through the
 ThreatConnect API. The primary classes in the Reader Package, which
 encompass all read functionality from the API, are listed below.
 
-+-----------------------------------------------------------+
-| Class                                                     |
-+===========================================================+
-| ``ReaderAdapterFactory``                                  |
-+-----------------------------------------------------------+
-| ``AbstractGroupReaderAdapter<T extends Group>``           |
-+-----------------------------------------------------------+
-| ``AbstractIndicatorReaderAdapter<T extends Indicator>``   |
-+-----------------------------------------------------------+
-| ``AbstractReaderAdapter``                                 |
-+-----------------------------------------------------------+
-| ``OwnerReaderAdapter``                                    |
-+-----------------------------------------------------------+
-| ``SecurityLabelReaderAdapter``                            |
-+-----------------------------------------------------------+
-| ``TagReaderAdapter``                                      |
-+-----------------------------------------------------------+
-| ``TaskReaderAdapter``                                     |
-+-----------------------------------------------------------+
-| ``VictimReaderAdapter``                                   |
-+-----------------------------------------------------------+
++--------------------------------------+---------------------------------+
+| Class                                | *Description*                   |
++======================================+=================================+
+| ``ReaderAdapterFactory``             | Primary entry point to          |
+|                                      | instantiate all readers in the  |
+|                                      | Reader Package.                 |
++--------------------------------------+---------------------------------+
+| ``AbstractGroupReaderAdapter<T exten | Generic Group Reader Abstract   |
+| ds Group>``                          | class. Concrete object          |
+|                                      | available in                    |
+|                                      | ReaderAdapterFactory.           |
++--------------------------------------+---------------------------------+
+| ``AbstractIndicatorReaderAdapter<T e | Generic Indicator Reader        |
+| xtends Indicator>``                  | Abstract class. Concrete object |
+|                                      | available in                    |
+|                                      | ReaderAdapterFactory.           |
++--------------------------------------+---------------------------------+
+| ``AbstractReaderAdapter``            | Base Abstract Reader for all    |
+|                                      | Reader Adapters in the Reader   |
+|                                      | Package.                        |
++--------------------------------------+---------------------------------+
+| ``OwnerReaderAdapter``               | Concrete Reader for             |
+|                                      | Organization owner data.        |
+|                                      | Convenience object available in |
+|                                      | ReaderAdapterFactory.           |
++--------------------------------------+---------------------------------+
+| ``SecurityLabelReaderAdapter``       | Concrete Reader for             |
+|                                      | SecurityLabel data. Convenience |
+|                                      | object available in             |
+|                                      | ReaderAdapterFactory.           |
++--------------------------------------+---------------------------------+
+| ``TagReaderAdapter``                 | Concrete Reader for Tag data.   |
+|                                      | Convenience object available in |
+|                                      | ReaderAdapterFactory.           |
++--------------------------------------+---------------------------------+
+| ``TaskReaderAdapter``                | Concrete Reader for Task data.  |
+|                                      | Convenience object available in |
+|                                      | ReaderAdapterFactory.           |
++--------------------------------------+---------------------------------+
+| ``VictimReaderAdapter``              | Concrete Reader for Victim      |
+|                                      | data. Convenience object        |
+|                                      | available in                    |
+|                                      | ReaderAdapterFactory.           |
++--------------------------------------+---------------------------------+
 
 Reader Factory
 ~~~~~~~~~~~~~~
@@ -462,43 +485,44 @@ Adapters. It provides convenience objects for all the Adapters in the
 Reader Package. Below is a list of the static methods and return types
 of the ReaderAdapterFactory:
 
-+-----------------------------------------------------------+
-| Type                                                      |
-+===========================================================+
-| ``static AbstractGroupReaderAdapter<Adversary>``          |
-+-----------------------------------------------------------+
-| ``static AbstractGroupReaderAdapter<Email>``              |
-+-----------------------------------------------------------+
-| ``static AbstractGroupReaderAdapter<Incident>``           |
-+-----------------------------------------------------------+
-| ``static AbstractGroupReaderAdapter<Signature>``          |
-+-----------------------------------------------------------+
-| ``static AbstractGroupReaderAdapter<Threat>``             |
-+-----------------------------------------------------------+
-| ``static AbstractIndicatorReaderAdapter<Address>``        |
-+-----------------------------------------------------------+
-| ``static AbstractIndicatorReaderAdapter<EmailAddress>``   |
-+-----------------------------------------------------------+
-| ``static AbstractIndicatorReaderAdapter<File>``           |
-+-----------------------------------------------------------+
-| ``static AbstractIndicatorReaderAdapter<Host>``           |
-+-----------------------------------------------------------+
-| ``static AbstractIndicatorReaderAdapter<Url>``            |
-+-----------------------------------------------------------+
-| ``static BatchReaderAdapter<Indicator>``                  |
-+-----------------------------------------------------------+
-| ``static DocumentReaderAdapter``                          |
-+-----------------------------------------------------------+
-| ``static OwnerReaderAdapter``                             |
-+-----------------------------------------------------------+
-| ``static SecurityLabelReaderAdapter``                     |
-+-----------------------------------------------------------+
-| ``static TagReaderAdapter``                               |
-+-----------------------------------------------------------+
-| ``static TaskReaderAdapter``                              |
-+-----------------------------------------------------------+
-| ``static VictimReaderAdapter``                            |
-+-----------------------------------------------------------+
+
++---------------------------------------------------------+----------------------------------------------------+
+| Type                                                    | Method                                             |
++=========================================================+====================================================+
+| ``static AbstractGroupReaderAdapter<Adversary>``        | createAdversaryGroupReader(Connection conn)        |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractGroupReaderAdapter<Email>``            | createEmailGroupReader(Connection conn)            |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractGroupReaderAdapter<Incident>``         | createIncidentGroupReader(Connection conn)         |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractGroupReaderAdapter<Signature>``        | createSignatureGroupReader(Connection conn)        |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractGroupReaderAdapter<Threat>``           | createThreatGroupReader(Connection conn)           |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorReaderAdapter<Address>``      | createAddressIndicatorReader(Connection conn)      |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorReaderAdapter<EmailAddress>`` | createEmailAddressIndicatorReader(Connection conn) |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorReaderAdapter<File>``         | createFileIndicatorReader(Connection conn)         |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorReaderAdapter<Host>``         | createHostIndicatorReader(Connection conn)         |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorReaderAdapter<Url>``          | createUrlIndicatorReader(Connection conn)          |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static BatchReaderAdapter<Indicator>``                | createIndicatorBatchReader(Connection conn)        |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static DocumentReaderAdapter``                        | createDocumentReader(Connection conn)              |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static OwnerReaderAdapter``                           | createOwnerReader(Connection conn)                 |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static SecurityLabelReaderAdapter``                   | createSecurityLabelReader(Connection conn)         |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static TagReaderAdapter``                             | createTagReader(Connection conn)                   |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static TaskReaderAdapter``                            | createTaskReader(Connection conn)                  |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static VictimReaderAdapter``                          | createVictimReader(Connection conn)                |
++---------------------------------------------------------+----------------------------------------------------+
 
 Reader Factory Example
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -733,249 +757,248 @@ AbstractGroupReaderAdapter
 The methods below get data for the Group type (T) linked to this
 Adapter. The uniqueId (P) for Groups is an Integer.
 
-+---------------------------+
-| Type                      |
-+===========================+
-| ``T``                     |
-+---------------------------+
-| ``T``                     |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
++-------------------------+----------------------------------------------------------------------------+
+| Type                    | Method                                                                     |
++=========================+============================================================================+
+| ``T``                   | getById(P uniqueId)                                                        |
++-------------------------+----------------------------------------------------------------------------+
+| ``T``                   | getById(P uniqueId, String ownerName)                                      |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getForFilters(String ownerName, boolean orParams, ApiFilterType...filters) |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll()                                                                   |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll(String ownerName)                                                   |
++-------------------------+----------------------------------------------------------------------------+
 
 The methods below get generic Group objects associated to this Group
 type (T).
 
-+-------------------------------+
-| Type                          |
-+===============================+
-| ``IterableResponse<Group>``   |
-+-------------------------------+
-| ``IterableResponse<Group>``   |
-+-------------------------------+
-| ``String``                    |
-+-------------------------------+
++-----------------------------+--------------------------------+
+| Type                        | Method                         |
++=============================+================================+
+| ``IterableResponse<Group>`` | getAllGroups()                 |
++-----------------------------+--------------------------------+
+| ``IterableResponse<Group>`` | getAllGroups(String ownerName) |
++-----------------------------+--------------------------------+
+| ``String``                  | getAllGroupsAsText()           |
++-----------------------------+--------------------------------+
 
 Associated Groups
 ~~~~~~~~~~~~~~~~~
 
 The methods below get associated Group elements by distinct type.
 
-+-----------------------------------+
-| Type                              |
-+===================================+
-| ``IterableResponse<Group>``       |
-+-----------------------------------+
-| ``IterableResponse<Group>``       |
-+-----------------------------------+
-| ``IterableResponse<Adversary>``   |
-+-----------------------------------+
-| ``IterableResponse<Adversary>``   |
-+-----------------------------------+
-| ``Adversary``                     |
-+-----------------------------------+
-| ``Adversary``                     |
-+-----------------------------------+
-| ``IterableResponse<Email>``       |
-+-----------------------------------+
-| ``IterableResponse<Email>``       |
-+-----------------------------------+
-| ``Email``                         |
-+-----------------------------------+
-| ``Email``                         |
-+-----------------------------------+
-| ``IterableResponse<Incident>``    |
-+-----------------------------------+
-| ``IterableResponse<Incident>``    |
-+-----------------------------------+
-| ``Incident``                      |
-+-----------------------------------+
-| ``Incident``                      |
-+-----------------------------------+
-| ``IterableResponse<Signature>``   |
-+-----------------------------------+
-| ``IterableResponse<Signature>``   |
-+-----------------------------------+
-| ``Signature``                     |
-+-----------------------------------+
-| ``Signature``                     |
-+-----------------------------------+
-| ``IterableResponse<Threat>``      |
-+-----------------------------------+
-| ``IterableResponse<Threat>``      |
-+-----------------------------------+
-| ``Threat``                        |
-+-----------------------------------+
-| ``Threat``                        |
-+-----------------------------------+
++---------------------------------+--------------------------------------------------------------------------------------+
+| Type                            | Method                                                                               |
++=================================+======================================================================================+
+| ``IterableResponse<Group>``     | getAssociatedGroups(Integer uniqueId)                                                |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Group>``     | getAssociatedGroups(Integer uniqueId, String ownerName)                              |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Adversary>`` | getAssociatedGroupAdversaries(Integer uniqueId)                                      |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Adversary>`` | getAssociatedGroupAdversaries(Integer uniqueId, String ownerName)                    |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Adversary``                   | getAssociatedGroupAdversary(Integer uniqueId, Integer adversaryId)                   |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Adversary``                   | getAssociatedGroupAdversary(Integer uniqueId, Integer adversaryId, String ownerName) |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Email>``     | getAssociatedGroupEmails(Integer uniqueId)                                           |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Email>``     | getAssociatedGroupEmails(Integer uniqueId, String ownerName)                         |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Email``                       | getAssociatedGroupEmail(Integer uniqueId, Integer emailId)                           |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Email``                       | getAssociatedGroupEmail(Integer uniqueId, Integer emailId, String ownerName)         |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Incident>``  | getAssociatedGroupIncidents(Integer uniqueId)                                        |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Incident>``  | getAssociatedGroupIncidents(Integer uniqueId, String ownerName)                      |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Incident``                    | getAssociatedGroupIncident(Integer uniqueId, Integer incidentId)                     |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Incident``                    | getAssociatedGroupIncident(Integer uniqueId, Integer incidentId, String ownerName)   |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Signature>`` | getAssociatedGroupSignatures(Integer uniqueId)                                       |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Signature>`` | getAssociatedGroupSignatures(Integer uniqueId, String ownerName)                     |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Signature``                   | getAssociatedGroupSignature(Integer uniqueId, Integer signatureId)                   |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Signature``                   | getAssociatedGroupSignature(Integer uniqueId, Integer signatureId, String ownerName) |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Threat>``    | getAssociatedGroupThreats(Integer uniqueId)                                          |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Threat>``    | getAssociatedGroupThreats(Integer uniqueId, String ownerName)                        |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Threat``                      | getAssociatedGroupThreat(Integer uniqueId, Integer threatId)                         |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Threat``                      | getAssociatedGroupThreat(Integer uniqueId, Integer threatId, String ownerName)       |
++---------------------------------+--------------------------------------------------------------------------------------+
 
 Associated Indicators
 ~~~~~~~~~~~~~~~~~~~~~
 
 The methods below get associated Indicator elements by distinct types.
 
-+-----------------------------------+
-| Type                              |
-+===================================+
-| ``IterableResponse<Indicator>``   |
-+-----------------------------------+
-| ``IterableResponse<Indicator>``   |
-+-----------------------------------+
-| ``IterableResponse<Address>``     |
-+-----------------------------------+
-| ``IterableResponse<Address>``     |
-+-----------------------------------+
-| ``Address``                       |
-+-----------------------------------+
-| ``Address``                       |
-+-----------------------------------+
-| ``IterableResponse<Email>``       |
-+-----------------------------------+
-| ``IterableResponse<Email>``       |
-+-----------------------------------+
-| ``Email``                         |
-+-----------------------------------+
-| ``Email``                         |
-+-----------------------------------+
-| ``IterableResponse<File>``        |
-+-----------------------------------+
-| ``IterableResponse<File>``        |
-+-----------------------------------+
-| ``File``                          |
-+-----------------------------------+
-| ``IterableResponse<Host>``        |
-+-----------------------------------+
-| ``IterableResponse<Host>``        |
-+-----------------------------------+
-| ``Host``                          |
-+-----------------------------------+
-| ``Host``                          |
-+-----------------------------------+
-| ``IterableResponse<Url>``         |
-+-----------------------------------+
-| ``IterableResponse<Url>``         |
-+-----------------------------------+
-| ``Url``                           |
-+-----------------------------------+
-| ``Url``                           |
-+-----------------------------------+
++---------------------------------+--------------------------------------------------------------------------------------+
+| Type                            | Method                                                                               |
++=================================+======================================================================================+
+| ``IterableResponse<Indicator>`` | getAssociatedIndicators(Integer uniqueId)                                            |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Indicator>`` | getAssociatedIndicators(Integer uniqueId, String ownerName)                          |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Address>``   | getAssociatedIndicatorAddresses(Integer uniqueId)                                    |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Address>``   | getAssociatedIndicatorAddresses(Integer uniqueId, String ownerName)                  |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Address``                     | getAssociatedIndicatorAddress(Integer uniqueId, String ipAddress)                    |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Address``                     | getAssociatedIndicatorAddress(Integer uniqueId, String ipAddress, String ownerName)  |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Email>``     | getAssociatedIndicatorEmails(Integer uniqueId)                                       |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Email>``     | getAssociatedIndicatorEmails(Integer uniqueId, String ownerName)                     |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Email``                       | getAssociatedIndicatorEmail(Integer uniqueId, String emailAddress)                   |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Email``                       | getAssociatedIndicatorEmail(Integer uniqueId, String emailAddress, String ownerName) |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<File>``      | getAssociatedIndicatorFiles(Integer uniqueId)                                        |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<File>``      | getAssociatedIndicatorFiles(Integer uniqueId, String ownerName)                      |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``File``                        | getAssociatedIndicatorFile(Integer uniqueId, String fileHash)                        |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Host>``      | getAssociatedIndicatorHosts(Integer uniqueId)                                        |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Host>``      | getAssociatedIndicatorHosts(Integer uniqueId, String ownerName)                      |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Host``                        | getAssociatedIndicatorHost(Integer uniqueId, String hostName)                        |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Host``                        | getAssociatedIndicatorHost(Integer uniqueId, String hostName, String ownerName)      |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Url>``       | getAssociatedIndicatorUrls(Integer uniqueId)                                         |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<Url>``       | getAssociatedIndicatorUrls(Integer uniqueId, String ownerName)                       |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Url``                         | getAssociatedIndicatorUrl(Integer uniqueId, String urlText)                          |
++---------------------------------+--------------------------------------------------------------------------------------+
+| ``Url``                         | getAssociatedIndicatorUrl(Integer uniqueId, String urlText, String ownerName)        |
++---------------------------------+--------------------------------------------------------------------------------------+
 
 Associated Security Labels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The methods below get associated SecurityLabel data elements.
 
-+---------------------------------------+
-| Type                                  |
-+=======================================+
-| ``IterableResponse<SecurityLabel>``   |
-+---------------------------------------+
-| ``IterableResponse<SecurityLabel>``   |
-+---------------------------------------+
-| ``SecurityLabel``                     |
-+---------------------------------------+
-| ``SecurityLabel``                     |
-+---------------------------------------+
++-------------------------------------+--------------------------------------------------------------------------------------+
+| Type                                | Method                                                                               |
++=====================================+======================================================================================+
+| ``IterableResponse<SecurityLabel>`` | getAssociatedSecurityLabels(Integer uniqueId)                                        |
++-------------------------------------+--------------------------------------------------------------------------------------+
+| ``IterableResponse<SecurityLabel>`` | getAssociatedSecurityLabels(Integer uniqueId, String ownerName)                      |
++-------------------------------------+--------------------------------------------------------------------------------------+
+| ``SecurityLabel``                   | getAssociatedSecurityLabel(Integer uniqueId, String securityLabel)                   |
++-------------------------------------+--------------------------------------------------------------------------------------+
+| ``SecurityLabel``                   | getAssociatedSecurityLabel(Integer uniqueId, String securityLabel, String ownerName) |
++-------------------------------------+--------------------------------------------------------------------------------------+
 
 Associated Tags
 ~~~~~~~~~~~~~~~
 
 The methods below get associated Tag data elements.
 
-+-----------------------------+
-| Type                        |
-+=============================+
-| ``IterableResponse<Tag>``   |
-+-----------------------------+
-| ``IterableResponse<Tag>``   |
-+-----------------------------+
-| ``Tag``                     |
-+-----------------------------+
-| ``Tag``                     |
-+-----------------------------+
++---------------------------+----------------------------------------------------------------------+
+| Type                      | Method                                                               |
++===========================+======================================================================+
+| ``IterableResponse<Tag>`` | getAssociatedTags(Integer uniqueId)                                  |
++---------------------------+----------------------------------------------------------------------+
+| ``IterableResponse<Tag>`` | getAssociatedTags(Integer uniqueId, String ownerName)                |
++---------------------------+----------------------------------------------------------------------+
+| ``Tag``                   | getAssociatedTag(Integer uniqueId, String tagName)                   |
++---------------------------+----------------------------------------------------------------------+
+| ``Tag``                   | getAssociatedTag(Integer uniqueId, String tagName, String ownerName) |
++---------------------------+----------------------------------------------------------------------+
 
 Associated VictimAssets
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The methods below get associated VictimAsset data elements.
 
-+----------------------------------------------+
-| Type                                         |
-+==============================================+
-| ``IterableResponse<VictimAsset>``            |
-+----------------------------------------------+
-| ``IterableResponse<VictimAsset>``            |
-+----------------------------------------------+
-| ``IterableResponse<VictimEmailAddress>``     |
-+----------------------------------------------+
-| ``IterableResponse<VictimEmailAddress>``     |
-+----------------------------------------------+
-| ``VictimEmailAddress``                       |
-+----------------------------------------------+
-| ``VictimEmailAddress``                       |
-+----------------------------------------------+
-| ``IterableResponse<VictimNetworkAccount>``   |
-+----------------------------------------------+
-| ``IterableResponse<VictimNetworkAccount>``   |
-+----------------------------------------------+
-| ``VictimNetworkAccount``                     |
-+----------------------------------------------+
-| ``VictimNetworkAccount``                     |
-+----------------------------------------------+
-| ``IterableResponse<VictimPhone>``            |
-+----------------------------------------------+
-| ``IterableResponse<VictimPhone>``            |
-+----------------------------------------------+
-| ``VictimPhone``                              |
-+----------------------------------------------+
-| ``VictimPhone``                              |
-+----------------------------------------------+
-| ``IterableResponse<VictimSocialNetwork>``    |
-+----------------------------------------------+
-| ``IterableResponse<VictimSocialNetwork>``    |
-+----------------------------------------------+
-| ``VictimSocialNetwork``                      |
-+----------------------------------------------+
-| ``VictimSocialNetwork``                      |
-+----------------------------------------------+
-| ``IterableResponse<VictimWebSite>``          |
-+----------------------------------------------+
-| ``IterableResponse<VictimWebSite>``          |
-+----------------------------------------------+
-| ``VictimWebSite``                            |
-+----------------------------------------------+
-| ``VictimWebSite``                            |
-+----------------------------------------------+
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| Type                                       | Method                                                                                      |
++============================================+=============================================================================================+
+| ``IterableResponse<VictimAsset>``          | getAssociatedVictimAssets(Integer uniqueId)                                                 |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimAsset>``          | getAssociatedVictimAssets(Integer uniqueId, String ownerName)                               |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimEmailAddress>``   | getAssociatedVictimAssetEmailAddresses(Integer uniqueId)                                    |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimEmailAddress>``   | getAssociatedVictimAssetEmailAddresses(Integer uniqueId, String ownerName)                  |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimEmailAddress``                     | getAssociatedVictimAssetEmailAddress(Integer uniqueId, Integer assetId)                     |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimEmailAddress``                     | getAssociatedVictimAssetEmailAddress(Integer uniqueId, Integer assetId, String ownerName)   |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimNetworkAccount>`` | getAssociatedVictimAssetNetworkAccounts(Integer uniqueId)                                   |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimNetworkAccount>`` | getAssociatedVictimAssetNetworkAccounts(Integer uniqueId, String ownerName)                 |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimNetworkAccount``                   | getAssociatedVictimAssetNetworkAccount(Integer uniqueId, Integer assetId)                   |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimNetworkAccount``                   | getAssociatedVictimAssetNetworkAccount(Integer uniqueId, Integer assetId, String ownerName) |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimPhone>``          | getAssociatedVictimAssetPhoneNumbers(Integer uniqueId)                                      |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimPhone>``          | getAssociatedVictimAssetPhoneNumbers(Integer uniqueId, String ownerName)                    |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimPhone``                            | getAssociatedVictimAssetPhoneNumber(Integer uniqueId, Integer assetId)                      |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimPhone``                            | getAssociatedVictimAssetPhoneNumber(Integer uniqueId, Integer assetId, String ownerName)    |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimSocialNetwork>``  | getAssociatedVictimAssetSocialNetworks(Integer uniqueId)                                    |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimSocialNetwork>``  | getAssociatedVictimAssetSocialNetworks(Integer uniqueId, String ownerName)                  |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimSocialNetwork``                    | getAssociatedVictimAssetSocialNetwork(Integer uniqueId, Integer assetId)                    |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimSocialNetwork``                    | getAssociatedVictimAssetSocialNetwork(Integer uniqueId, Integer assetId, String ownerName)  |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimWebSite>``        | getAssociatedVictimAssetWebsites(Integer uniqueId)                                          |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``IterableResponse<VictimWebSite>``        | getAssociatedVictimAssetWebsites(Integer uniqueId, String ownerName)                        |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimWebSite``                          | getAssociatedVictimAssetWebsite(Integer uniqueId, Integer assetId)                          |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
+| ``VictimWebSite``                          | getAssociatedVictimAssetWebsite(Integer uniqueId, Integer assetId, String ownerName)        |
++--------------------------------------------+---------------------------------------------------------------------------------------------+
 
 Associated Attributes
 ~~~~~~~~~~~~~~~~~~~~~
 
-The methods below get Attributes and Attribute SecurityLabels for this
-Group type.
+The methods below get Attributes and Attribute SecurityLabels for this Group type.
 
-+---------------------------------------+
-| Type                                  |
-+=======================================+
-| ``IterableResponse<Attribute>``       |
-+---------------------------------------+
-| ``IterableResponse<Attribute>``       |
-+---------------------------------------+
-| ``Attribute``                         |
-+---------------------------------------+
-| ``Attribute``                         |
-+---------------------------------------+
-| ``IterableResponse<SecurityLabel>``   |
-+---------------------------------------+
-| ``IterableResponse<SecurityLabel>``   |
-+---------------------------------------+
-| ``SecurityLabel``                     |
-+---------------------------------------+
-| ``SecurityLabel``                     |
-+---------------------------------------+
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
+| Type                                | Method                                                                                                   |
++=====================================+==========================================================================================================+
+| ``IterableResponse<Attribute>``     | getAttributes(Integer uniqueId)                                                                          |
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``IterableResponse<Attribute>``     | getAttributes(Integer uniqueId, String ownerName)                                                        |
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``Attribute``                       | getAttribute(Integer uniqueId, Integer attributeId)                                                      |
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``Attribute``                       | getAttribute(Integer uniqueId, Integer attributeId, String ownerName)                                    |
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``IterableResponse<SecurityLabel>`` | getAttributeSecurityLabels(Integer uniqueId, Integer attributeId)                                        |
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``IterableResponse<SecurityLabel>`` | getAttributeSecurityLabels(Integer uniqueId, Integer attributeId, String ownerName)                      |
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``SecurityLabel``                   | getAttributeSecurityLabel(Integer uniqueId, Integer attributeId, String securityLabel)                   |
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``SecurityLabel``                   | getAttributeSecurityLabel(Integer uniqueId, Integer attributeId, String securityLabel, String ownerName) |
++-------------------------------------+----------------------------------------------------------------------------------------------------------+
 
 AbstractIndicatorReaderAdapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -994,252 +1017,225 @@ ThreatConnect API documentation.
 The methods below get data for the Indicator type (T) linked to this
 Adapter. The uniqueId (P) for Indicators is a String.
 
-+---------------------------+
-| Type                      |
-+===========================+
-| ``T``                     |
-+---------------------------+
-| ``T``                     |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
++-------------------------+----------------------------------------------------------------------------+
+| Type                    | Method                                                                     |
++=========================+============================================================================+
+| ``T``                   | getById(P uniqueId)                                                        |
++-------------------------+----------------------------------------------------------------------------+
+| ``T``                   | getById(P uniqueId, String ownerName)                                      |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getForFilters(String ownerName, boolean orParams, ApiFilterType...filters) |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll()                                                                   |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll(String ownerName)                                                   |
++-------------------------+----------------------------------------------------------------------------+
 
-The method below returns all the generic Indicators to which the current
-API user has access.
+The method below returns all the generic Indicators to which the current API user has access.
 
-+-----------------------------------+
-| Type                              |
-+===================================+
-| ``IterableResponse<Indicator>``   |
-+-----------------------------------+
++---------------------------------+-----------------+
+| Type                            | Method          |
++=================================+=================+
+| ``IterableResponse<Indicator>`` | getIndicators() |
++---------------------------------+-----------------+
 
-The methods below return owners who have created the Indicator under the
-uniqueId.
+The methods below return owners who have created the Indicator under the uniqueId.
 
-+-------------------------------+
-| Type                          |
-+===============================+
-| ``IterableResponse<Owner>``   |
-+-------------------------------+
-| ``IterableResponse<Owner>``   |
-+-------------------------------+
++-----------------------------+--------------------------------------------------------+
+| Type                        | Method                                                 |
++=============================+========================================================+
+| ``IterableResponse<Owner>`` | getAssociatedOwners(String uniqueId)                   |
++-----------------------------+--------------------------------------------------------+
+| ``IterableResponse<Owner>`` | getAssociatedOwners(String uniqueId, String ownerName) |
++-----------------------------+--------------------------------------------------------+
 
-The methods below return False Positive counts for the Indicator under
-the uniqueId.
+The methods below return False Positive counts for the Indicator under the uniqueId.
 
-\|Type\|\ *Method* \|
--------------------------------------------------------- \|
-``FalsePositive``\ \|getFalsePositive(String uniqueId) \|
-``FalsePositive``\ \|getFalsePositive(String uniqueId, String ownerName)
-\|
+\|Type\|Method \| -------------------------------------------------------- \|
+``FalsePositive``\ \|getFalsePositive(String uniqueId) \| ``FalsePositive``\ \|getFalsePositive(String uniqueId, String
+ownerName) \|
 
-The methods below return Observations and Observation counts for the
-Indicator under the uniqueId.
+The methods below return Observations and Observation counts for the Indicator under the uniqueId.
 
-+-------------------------------------+
-| Type                                |
-+=====================================+
-| ``IterableResponse<Observation>``   |
-+-------------------------------------+
-| ``IterableResponse<Observation>``   |
-+-------------------------------------+
-| ``ObservationCount``                |
-+-------------------------------------+
-| ``ObservationCount``                |
-+-------------------------------------+
++-----------------------------------+--------------------------------------------------------+
+| Type                              | Method                                                 |
++===================================+========================================================+
+| ``IterableResponse<Observation>`` | getObservations(String uniqueId)                       |
++-----------------------------------+--------------------------------------------------------+
+| ``IterableResponse<Observation>`` | getObservations(String uniqueId, String ownerName)     |
++-----------------------------------+--------------------------------------------------------+
+| ``ObservationCount``              | getObservationCount(String uniqueId)                   |
++-----------------------------------+--------------------------------------------------------+
+| ``ObservationCount``              | getObservationCount(String uniqueId, String ownerName) |
++-----------------------------------+--------------------------------------------------------+
 
-The AbstractIndicatorReaderAdapter class has a concrete subclass
-**FileIndicatorReaderAdapter** that exposes the methods below.
+The AbstractIndicatorReaderAdapter class has a concrete subclass **FileIndicatorReaderAdapter** that exposes the methods
+below.
 
-+----------------------+
-| Type                 |
-+======================+
-| ``FileOccurrence``   |
-+----------------------+
-| ``FileOccurrence``   |
-+----------------------+
++--------------------+-------------------------------------------------------------------------------+
+| Type               | Method                                                                        |
++====================+===============================================================================+
+| ``FileOccurrence`` | getFileOccurrence(String uniqueId, Integer fileOccurrencId)                   |
++--------------------+-------------------------------------------------------------------------------+
+| ``FileOccurrence`` | getFileOccurrence(String uniqueId, Integer fileOccurrencId, String ownerName) |
++--------------------+-------------------------------------------------------------------------------+
 
 BatchReaderAdapter
 ~~~~~~~~~~~~~~~~~~
 
-The BatchReaderAdapter class allows the developer to poll for the status
-of a batch upload file using a batch id. Once a batch is complete
-(either successfully or with errors), the developer can download errors
-(if any).
+The BatchReaderAdapter class allows the developer to poll for the status of a batch upload file using a batch id. Once a
+batch is complete (either successfully or with errors), the developer can download errors (if any).
 
-+---------------------------------------------------------------------+
-| Type                                                                |
-+=====================================================================+
-| ``ApiEntitySingleResponse<BatchStatus, BatchStatusResponseData>``   |
-+---------------------------------------------------------------------+
-| ``ApiEntitySingleResponse<BatchStatus, BatchStatusResponseData>``   |
-+---------------------------------------------------------------------+
-| ``void``                                                            |
-+---------------------------------------------------------------------+
-| ``void``                                                            |
-+---------------------------------------------------------------------+
++-------------------------------------------------------------------+----------------------------------------------------------------+
+| Type                                                              | Method                                                         |
++===================================================================+================================================================+
+| ``ApiEntitySingleResponse<BatchStatus, BatchStatusResponseData>`` | getStatus(int batchId)                                         |
++-------------------------------------------------------------------+----------------------------------------------------------------+
+| ``ApiEntitySingleResponse<BatchStatus, BatchStatusResponseData>`` | getStatus(int batchId, String ownerName)                       |
++-------------------------------------------------------------------+----------------------------------------------------------------+
+| ``void``                                                          | downloadErrors(int batchId, Path outputPath)                   |
++-------------------------------------------------------------------+----------------------------------------------------------------+
+| ``void``                                                          | downloadErrors(int batchId, String ownerName, Path outputPath) |
++-------------------------------------------------------------------+----------------------------------------------------------------+
 
 DocumentReaderAdapter
 ~~~~~~~~~~~~~~~~~~~~~
 
-The DocumentReaderAdapter class is a subclass of the AbstractGroupReader
-class. In addition to all GroupReader functionality, the document reader
-has access to the following method.
+The DocumentReaderAdapter class is a subclass of the AbstractGroupReader class. In addition to all GroupReader
+functionality, the document reader has access to the following method.
 
-+------------+
-| Type       |
-+============+
-| ``void``   |
-+------------+
++----------+---------------------------------------------------------------+
+| Type     | Method                                                        |
++==========+===============================================================+
+| ``void`` | downloadFile(int uniqueId, String ownerName, Path outputPath) |
++----------+---------------------------------------------------------------+
 
 OwnerReaderAdapter
 ~~~~~~~~~~~~~~~~~~
 
-The OwnerReaderAdapter is a simple Adapter that returns a list of
-Organizations to which the API user has access. There is a second method
-called "getOwnerMine()" that returns the default Organization for the
-API user.
+The OwnerReaderAdapter is a simple Adapter that returns a list of Organizations to which the API user has access. There
+is a second method called "getOwnerMine()" that returns the default Organization for the API user.
 
-+-------------------------------+
-| Type                          |
-+===============================+
-| ``Owner``                     |
-+-------------------------------+
-| ``IterableResponse<Owner>``   |
-+-------------------------------+
++-----------------------------+----------------+
+| Type                        | Method         |
++=============================+================+
+| ``Owner``                   | getOwnerMine() |
++-----------------------------+----------------+
+| ``IterableResponse<Owner>`` | getOwners()    |
++-----------------------------+----------------+
 
 SecurityLabelReaderAdapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The SecurityLabelReaderAdapter class is a concrete class (available
-through the ReaderFactory) that returns SecurityLabels to which the
-developer's API user has access, as well as by uniqueId (P). The
-uniqueId data type for SecurityLabels is a String.
+The SecurityLabelReaderAdapter class is a concrete class (available through the ReaderFactory) that returns
+SecurityLabels to which the developer's API user has access, as well as by uniqueId (P). The uniqueId data type for
+SecurityLabels is a String.
 
-+---------------------------+
-| Type                      |
-+===========================+
-| ``T``                     |
-+---------------------------+
-| ``T``                     |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
++-------------------------+---------------------------------------+
+| Type                    | Method                                |
++=========================+=======================================+
+| ``T``                   | getById(P uniqueId)                   |
++-------------------------+---------------------------------------+
+| ``T``                   | getById(P uniqueId, String ownerName) |
++-------------------------+---------------------------------------+
+| ``IterableResponse<T>`` | getAll()                              |
++-------------------------+---------------------------------------+
+| ``IterableResponse<T>`` | getAll(String ownerName)              |
++-------------------------+---------------------------------------+
 
-In addition to retrieving basic SecurityLabel data, associated
-`Groups <#associate-groups>`__ and
-`Indicators <#associate-indicators>`__ can be retrieved. For more
-details on these methods, see the
+In addition to retrieving basic SecurityLabel data, associated `Groups <#associate-groups>`__ and
+`Indicators <#associate-indicators>`__ can be retrieved. For more details on these methods, see the
 `AbstractGroupReaderAdapter <#abstractgroupreaderadapter>`__ class.
 
 TagReaderAdapter Class
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The TagReaderAdapter class is a concrete class (available through the
-ReaderFactory) that returns Tags to which the developer's API user has
-access, as well as by uniqueId (P). The uniqueId data type for Tags is a
-String.
+The TagReaderAdapter class is a concrete class (available through the ReaderFactory) that returns Tags to which the
+developer's API user has access, as well as by uniqueId (P). The uniqueId data type for Tags is a String.
 
-+---------------------------+
-| Type                      |
-+===========================+
-| ``T``                     |
-+---------------------------+
-| ``T``                     |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
++-------------------------+----------------------------------------------------------------------------+
+| Type                    | Method                                                                     |
++=========================+============================================================================+
+| ``T``                   | getById(P uniqueId)                                                        |
++-------------------------+----------------------------------------------------------------------------+
+| ``T``                   | getById(P uniqueId, String ownerName)                                      |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getForFilters(String ownerName, boolean orParams, ApiFilterType...filters) |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll()                                                                   |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll(String ownerName)                                                   |
++-------------------------+----------------------------------------------------------------------------+
 
-In addition to retrieving basic Tag data, associated
-`Groups <#associate-groups>`__ and
-`Indicators <#associate-indicators>`__ can be retrieved. For more
-details on these methods, review the
+In addition to retrieving basic Tag data, associated `Groups <#associate-groups>`__ and
+`Indicators <#associate-indicators>`__ can be retrieved. For more details on these methods, review the
 `AbstractGroupReaderAdapter <#abstractgroupreaderadapter>`__ class.
 
 TaskReaderAdapter Class
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The TaskReaderAdapter class is a concrete class (available through the
-ReaderFactory) that returns Tasks to which the API user has access, as
-well as by uniqueId (P). The uniqueId data type for a Task is an
-Integer.
+The TaskReaderAdapter class is a concrete class (available through the ReaderFactory) that returns Tasks to which the
+API user has access, as well as by uniqueId (P). The uniqueId data type for a Task is an Integer.
 
-+---------------------------+
-| Type                      |
-+===========================+
-| ``T``                     |
-+---------------------------+
-| ``T``                     |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
++-------------------------+----------------------------------------------------------------------------+
+| Type                    | Method                                                                     |
++=========================+============================================================================+
+| ``T``                   | getById(P uniqueId)                                                        |
++-------------------------+----------------------------------------------------------------------------+
+| ``T``                   | getById(P uniqueId, String ownerName)                                      |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getForFilters(String ownerName, boolean orParams, ApiFilterType...filters) |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll()                                                                   |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll(String ownerName)                                                   |
++-------------------------+----------------------------------------------------------------------------+
 
-In addition to retrieving basic Task data, associated Assignees and
-Escalatees can be retrieved.
+In addition to retrieving basic Task data, associated Assignees and Escalatees can be retrieved.
 
-The methods below return all Assignees or Escalatees associated with a
-given Task's id
+The methods below return all Assignees or Escalatees associated with a given Task's id
 
-+------------------------------+
-| Type                         |
-+==============================+
-| ``IterableResponse<User>``   |
-+------------------------------+
-| ``IterableResponse<User>``   |
-+------------------------------+
++----------------------------+---------------------------+
+| Type                       | Method                    |
++============================+===========================+
+| ``IterableResponse<User>`` | getAssignees(P uniqueId)  |
++----------------------------+---------------------------+
+| ``IterableResponse<User>`` | getEscalatees(P uniqueId) |
++----------------------------+---------------------------+
 
-The methods below return an individual Assignee or Escalatees'
-information
+The methods below return an individual Assignee or Escalatees' information
 
-+------------------------------+
-| Type                         |
-+==============================+
-| ``IterableResponse<User>``   |
-+------------------------------+
-| ``IterableResponse<User>``   |
-+------------------------------+
++----------------------------+-------------------------------------------+
+| Type                       | Method                                    |
++============================+===========================================+
+| ``IterableResponse<User>`` | getAssignee(P uniqueId, String userName)  |
++----------------------------+-------------------------------------------+
+| ``IterableResponse<User>`` | getEscalatee(P uniqueId, String userName) |
++----------------------------+-------------------------------------------+
 
 VictimReaderAdapter Class
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The VictimReaderAdapter class is a concrete class (available through the
-ReaderFactory) that returns Victims to which the API user has access, as
-well as by uniqueId (P). The uniqueId data type for a Victim is an
-Integer.
+The VictimReaderAdapter class is a concrete class (available through the ReaderFactory) that returns Victims to which
+the API user has access, as well as by uniqueId (P). The uniqueId data type for a Victim is an Integer.
 
-+---------------------------+
-| Type                      |
-+===========================+
-| ``T``                     |
-+---------------------------+
-| ``T``                     |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
-| ``IterableResponse<T>``   |
-+---------------------------+
++-------------------------+----------------------------------------------------------------------------+
+| Type                    | Method                                                                     |
++=========================+============================================================================+
+| ``T``                   | getById(P uniqueId)                                                        |
++-------------------------+----------------------------------------------------------------------------+
+| ``T``                   | getById(P uniqueId, String ownerName)                                      |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getForFilters(String ownerName, boolean orParams, ApiFilterType...filters) |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll()                                                                   |
++-------------------------+----------------------------------------------------------------------------+
+| ``IterableResponse<T>`` | getAll(String ownerName)                                                   |
++-------------------------+----------------------------------------------------------------------------+
 
-In addition to retrieving basic Victim data, associated
-`Groups <#associate-groups>`__, `Indicators <#associate-indicators>`__,
-and `VictimAssets <#associated-victimassets>`__ can be retrieved. For
-more details on these methods, review the
-`AbstractGroupReaderAdapter <#abstractgroupreaderadapter>`__ class.
+In addition to retrieving basic Victim data, associated `Groups <#associate-groups>`__,
+`Indicators <#associate-indicators>`__, and `VictimAssets <#associated-victimassets>`__ can be retrieved. For more
+details on these methods, review the `AbstractGroupReaderAdapter <#abstractgroupreaderadapter>`__ class.
 
 Reader IP Address and Tag Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1266,24 +1262,24 @@ Tags from our IP address Indicators:
      15     }
      16 
 
-+--------+-------------------------------------------------------------------+
-| Line   | Description                                                       |
-+========+===================================================================+
-| 3-4    | An IndicatorReaderAdapter is created to read all the addresses to |
-|        | which the API user has access. The ``getAll()`` method returns a  |
-|        | collection of addresses from the ThreatConnect API.               |
-+--------+-------------------------------------------------------------------+
-| 5-6    | Each address is iterated through and its uniqueId is printed. As  |
-|        | mentioned in the AbstractIndicatorReaderAdapter section, all      |
-|        | uniqueIds for Indicators are Strings. In the case of address      |
-|        | objects, it is the IP address or the ``getIp()`` getter method.   |
-+--------+-------------------------------------------------------------------+
-| 8      | To get a collection of associated Tags for the IP Address, the    |
-|        | ``getAssociatedTags()`` method is called.                         |
-+--------+-------------------------------------------------------------------+
-| 10-11  | Each Tag returned from the ThreatConnect API for that specific IP |
-|        | address is iterated through and printed to the console.           |
-+--------+-------------------------------------------------------------------+
++-------+-------------------------------------------------------------------+
+| Line  | Description                                                       |
++=======+===================================================================+
+| 3-4   | An IndicatorReaderAdapter is created to read all the addresses to |
+|       | which the API user has access. The ``getAll()`` method returns a  |
+|       | collection of addresses from the ThreatConnect API.               |
++-------+-------------------------------------------------------------------+
+| 5-6   | Each address is iterated through and its uniqueId is printed. As  |
+|       | mentioned in the AbstractIndicatorReaderAdapter section, all      |
+|       | uniqueIds for Indicators are Strings. In the case of address      |
+|       | objects, it is the IP address or the ``getIp()`` getter method.   |
++-------+-------------------------------------------------------------------+
+| 8     | To get a collection of associated Tags for the IP Address, the    |
+|       | ``getAssociatedTags()`` method is called.                         |
++-------+-------------------------------------------------------------------+
+| 10-11 | Each Tag returned from the ThreatConnect API for that specific IP |
+|       | address is iterated through and printed to the console.           |
++-------+-------------------------------------------------------------------+
 
 Summary
 
@@ -1355,58 +1351,41 @@ Writer Factory
 The primary methods for the WriterFactory are listed below. They
 encompass all write functionality for the ThreatConnect API.
 
-+----------------------------+-----------------------------------------------+
-| Class                      | *Method*                                      |
-+============================+===============================================+
-| ``static AbstractGroupWr   | createAdversaryGroupWriter(Connection conn)   |
-| iterAdapter<Adversary>``   |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractGroupWr   | createEmailGroupWriter(Connection conn)       |
-| iterAdapter<Email>``       |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractGroupWr   | createIncidentGroupWriter(Connection conn)    |
-| iterAdapter<Incident>``    |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractGroupWr   | createSignatureGroupWriter(Connection conn)   |
-| iterAdapter<Signature>``   |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractGroupWr   | createThreatGroupWriter(Connection conn)      |
-| iterAdapter<Threat>``      |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractIndicat   | createAddressIndicatorWriter(Connection conn) |
-| orWriterAdapter<Address>`` |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractIndicat   | createEmailAddressIndicatorWriter(Connection  |
-| orWriterAdapter<EmailAdd   | conn)                                         |
-| ress>``                    |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractIndicat   | createFileIndicatorWriter(Connection conn)    |
-| orWriterAdapter<File>``    |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractIndicat   | createHostIndicatorWriter(Connection conn)    |
-| orWriterAdapter<Host>``    |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractIndicat   | createUrlIndicatorWriter(Connection conn)     |
-| orWriterAdapter<Url>``     |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static AbstractBatchWr   | createBatchIndicatorWriter(Connection conn)   |
-| iterAdapter<Indicator>``   |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static DocumentWriterA   | createDocumentWriter(Connection conn)         |
-| dapter``                   |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static SecurityLabelWr   | createSecurityLabelWriter(Connection conn)    |
-| iterAdapter``              |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static TagWriterAdapte   | createTagWriter(Connection conn)              |
-| r``                        |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static TaskWriterAdapt   | createTaskWriter(Connection conn)             |
-| er``                       |                                               |
-+----------------------------+-----------------------------------------------+
-| ``static VictimWriterAda   | createVictimWriter(Connection conn)           |
-| pter``                     |                                               |
-+----------------------------+-----------------------------------------------+
++---------------------------------------------------------+----------------------------------------------------+
+| Class                                                   | Method                                             |
++=========================================================+====================================================+
+| ``static AbstractGroupWriterAdapter<Adversary>``        | createAdversaryGroupWriter(Connection conn)        |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractGroupWriterAdapter<Email>``            | createEmailGroupWriter(Connection conn)            |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractGroupWriterAdapter<Incident>``         | createIncidentGroupWriter(Connection conn)         |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractGroupWriterAdapter<Signature>``        | createSignatureGroupWriter(Connection conn)        |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractGroupWriterAdapter<Threat>``           | createThreatGroupWriter(Connection conn)           |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorWriterAdapter<Address>``      | createAddressIndicatorWriter(Connection conn)      |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorWriterAdapter<EmailAddress>`` | createEmailAddressIndicatorWriter(Connection conn) |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorWriterAdapter<File>``         | createFileIndicatorWriter(Connection conn)         |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorWriterAdapter<Host>``         | createHostIndicatorWriter(Connection conn)         |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractIndicatorWriterAdapter<Url>``          | createUrlIndicatorWriter(Connection conn)          |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static AbstractBatchWriterAdapter<Indicator>``        | createBatchIndicatorWriter(Connection conn)        |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static DocumentWriterAdapter``                        | createDocumentWriter(Connection conn)              |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static SecurityLabelWriterAdapter``                   | createSecurityLabelWriter(Connection conn)         |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static TagWriterAdapter``                             | createTagWriter(Connection conn)                   |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static TaskWriterAdapter``                            | createTaskWriter(Connection conn)                  |
++---------------------------------------------------------+----------------------------------------------------+
+| ``static VictimWriterAdapter``                          | createVictimWriter(Connection conn)                |
++---------------------------------------------------------+----------------------------------------------------+
 
 Writer Responses
 ~~~~~~~~~~~~~~~~
@@ -1470,67 +1449,67 @@ setters. Using the fluent entities in the
 ``com.threatconnect.sdk.client.fluent`` package are optional and a
 matter of preference.
 
-+-----------------------------------+
-| Fluent Types                      |
-+===================================+
-| ``AddressBuilder``                |
-+-----------------------------------+
-| ``AdversaryBuilder``              |
-+-----------------------------------+
-| ``AttributeBuilder``              |
-+-----------------------------------+
-| ``CommunityBuilder``              |
-+-----------------------------------+
-| ``DocumentBuilder``               |
-+-----------------------------------+
-| ``EmailAddressBuilder``           |
-+-----------------------------------+
-| ``EmailBuilder``                  |
-+-----------------------------------+
-| ``FileBuilder``                   |
-+-----------------------------------+
-| ``FileOccurrenceBuilder``         |
-+-----------------------------------+
-| ``GroupBuilder``                  |
-+-----------------------------------+
-| ``HostBuilder``                   |
-+-----------------------------------+
-| ``IncidentBuilder``               |
-+-----------------------------------+
-| ``IndicatorBuilder``              |
-+-----------------------------------+
-| ``IndividualBuilder``             |
-+-----------------------------------+
-| ``SecurityLabelBuilder``          |
-+-----------------------------------+
-| ``SignatureBuilder``              |
-+-----------------------------------+
-| ``SourceBuilder``                 |
-+-----------------------------------+
-| ``TagBuilder``                    |
-+-----------------------------------+
-| ``TaskBuilder``                   |
-+-----------------------------------+
-| ``ThreatBuilder``                 |
-+-----------------------------------+
-| ``UrlBuilder``                    |
-+-----------------------------------+
-| ``UserBuilder``                   |
-+-----------------------------------+
-| ``VictimAssetBuilder``            |
-+-----------------------------------+
-| ``VictimBuilder``                 |
-+-----------------------------------+
-| ``VictimEmailAddressBuilder``     |
-+-----------------------------------+
-| ``VictimNetworkAccountBuilder``   |
-+-----------------------------------+
-| ``VictimPhoneBuilder``            |
-+-----------------------------------+
-| ``VictimSocialNetworkBuilder``    |
-+-----------------------------------+
-| ``VictimWebSiteBuilder``          |
-+-----------------------------------+
++---------------------------------+
+| Fluent Types                    |
++=================================+
+| ``AddressBuilder``              |
++---------------------------------+
+| ``AdversaryBuilder``            |
++---------------------------------+
+| ``AttributeBuilder``            |
++---------------------------------+
+| ``CommunityBuilder``            |
++---------------------------------+
+| ``DocumentBuilder``             |
++---------------------------------+
+| ``EmailAddressBuilder``         |
++---------------------------------+
+| ``EmailBuilder``                |
++---------------------------------+
+| ``FileBuilder``                 |
++---------------------------------+
+| ``FileOccurrenceBuilder``       |
++---------------------------------+
+| ``GroupBuilder``                |
++---------------------------------+
+| ``HostBuilder``                 |
++---------------------------------+
+| ``IncidentBuilder``             |
++---------------------------------+
+| ``IndicatorBuilder``            |
++---------------------------------+
+| ``IndividualBuilder``           |
++---------------------------------+
+| ``SecurityLabelBuilder``        |
++---------------------------------+
+| ``SignatureBuilder``            |
++---------------------------------+
+| ``SourceBuilder``               |
++---------------------------------+
+| ``TagBuilder``                  |
++---------------------------------+
+| ``TaskBuilder``                 |
++---------------------------------+
+| ``ThreatBuilder``               |
++---------------------------------+
+| ``UrlBuilder``                  |
++---------------------------------+
+| ``UserBuilder``                 |
++---------------------------------+
+| ``VictimAssetBuilder``          |
++---------------------------------+
+| ``VictimBuilder``               |
++---------------------------------+
+| ``VictimEmailAddressBuilder``   |
++---------------------------------+
+| ``VictimNetworkAccountBuilder`` |
++---------------------------------+
+| ``VictimPhoneBuilder``          |
++---------------------------------+
+| ``VictimSocialNetworkBuilder``  |
++---------------------------------+
+| ``VictimWebSiteBuilder``        |
++---------------------------------+
 
 Writer Create Example
 ~~~~~~~~~~~~~~~~~~~~~
@@ -1633,31 +1612,31 @@ Adapter.
 -  The update methods require a Group type object as a collection or
    single object.
 
-+-------------------------------+--------------------------------------------------------+
-| Type                          | *Method*                                               |
-+===============================+========================================================+
-| ``WriteListResponse<T>``      | create(\ ``List<T> itemList``)                         |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | create(\ ``T item``)                                   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | create(\ ``T item``, ``String ownerName``)             |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<P>``      | delete(\ ``List<P> itemIds``)                          |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<P>``      | delete(\ ``List<P> itemIds``, ``String ownerName``)    |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | delete(\ ``P itemId``)                                 |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | delete(\ ``P itemId``, ``String ownerName``)           |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<T>``      | update(\ ``List<T> itemList``)                         |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<T>``      | update(\ ``List<T> itemList``, ``String ownerName``)   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | update(\ ``T item``)                                   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | update(\ ``T item``, ``String ownerName``)             |
-+-------------------------------+--------------------------------------------------------+
++-----------------------------+------------------------------------------------------+
+| Type                        | *Method*                                             |
++=============================+======================================================+
+| ``WriteListResponse<T>``    | create(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``)                        |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``, ``String ownerName``)  |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``)                               |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``, ``String ownerName``)         |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``, ``String ownerName``) |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
 
 Associate Groups
 ~~~~~~~~~~~~~~~~
@@ -1666,729 +1645,560 @@ The methods below associate a Group type to another Group type. Groups
 are associated by passing in the uniqueId (Integer) with the Group ID to
 which it will be associated.
 
-+----------------------+------------------------------------------------------+
-| Type                 | *Method*                                             |
-+======================+======================================================+
-| ``WriteListResponse< | associateGroupAdversaries(\ ``Integer uniqueId``,    |
-| Integer>``           | ``List<Integer> adversaryIds``)                      |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupAdversaries(\ ``Integer uniqueId``,    |
-| Integer>``           | ``List<Integer> adversaryIds``,                      |
-|                      | ``String ownerName``)                                |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupAdversary(\ ``Integer uniqueId``,      |
-| ponse``              | ``Integer adversaryId``)                             |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupAdversary(\ ``Integer uniqueId``,      |
-| ponse``              | ``Integer adversaryId``, ``String ownerName``)       |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupEmails(\ ``Integer uniqueId``,         |
-| Integer>``           | ``List<Integer> emailIds``)                          |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupEmails(\ ``Integer uniqueId``,         |
-| Integer>``           | ``List<Integer> emailIds``, ``String ownerName``)    |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupEmail(\ ``Integer uniqueId``,          |
-| ponse``              | ``Integer emailId``)                                 |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupEmail(\ ``Integer uniqueId``,          |
-| ponse``              | ``Integer emailId``, ``String ownerName``)           |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupIncidents(\ ``Integer uniqueId``,      |
-| Integer>``           | ``List<Integer> incidentIds``)                       |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupIncidents(\ ``Integer uniqueId``,      |
-| Integer>``           | ``List<Integer> incidentIds``, ``String ownerName``) |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupIncident(\ ``Integer uniqueId``,       |
-| ponse``              | ``Integer incidentId``)                              |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupIncident(\ ``Integer uniqueId``,       |
-| ponse``              | ``Integer incidentId``, ``String ownerName``)        |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupSignatures(\ ``Integer uniqueId``,     |
-| Integer>``           | ``List<Integer> signatureIds``)                      |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupSignatures(\ ``Integer uniqueId``,     |
-| Integer>``           | ``List<Integer> signatureIds``,                      |
-|                      | ``String ownerName``)                                |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupSignature(\ ``Integer uniqueId``,      |
-| ponse``              | ``Integer signatureId``)                             |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupSignature(\ ``Integer uniqueId``,      |
-| ponse``              | ``Integer signatureId``, ``String ownerName``)       |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupThreats(\ ``Integer uniqueId``,        |
-| Integer>``           | ``List<Integer> threatIds``)                         |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | associateGroupThreats(\ ``Integer uniqueId``,        |
-| Integer>``           | ``List<Integer> threatIds``, ``String ownerName``)   |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupThreat(\ ``Integer uniqueId``,         |
-| ponse``              | ``Integer threatId``)                                |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | associateGroupThreat(\ ``Integer uniqueId``,         |
-| ponse``              | ``Integer threatId``, ``String ownerName``)          |
-+----------------------+------------------------------------------------------+
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| Type                           | Method                                                                                                  |
++================================+=========================================================================================================+
+| ``WriteListResponse<Integer>`` | associateGroupAdversaries(\ ``Integer uniqueId``, ``List<Integer> adversaryIds``)                       |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupAdversaries(\ ``Integer uniqueId``, ``List<Integer> adversaryIds``, ``String ownerName``) |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupAdversary(\ ``Integer uniqueId``, ``Integer adversaryId``)                                |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupAdversary(\ ``Integer uniqueId``, ``Integer adversaryId``, ``String ownerName``)          |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupEmails(\ ``Integer uniqueId``, ``List<Integer> emailIds``)                                |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupEmails(\ ``Integer uniqueId``, ``List<Integer> emailIds``, ``String ownerName``)          |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupEmail(\ ``Integer uniqueId``, ``Integer emailId``)                                        |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupEmail(\ ``Integer uniqueId``, ``Integer emailId``, ``String ownerName``)                  |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupIncidents(\ ``Integer uniqueId``, ``List<Integer> incidentIds``)                          |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupIncidents(\ ``Integer uniqueId``, ``List<Integer> incidentIds``, ``String ownerName``)    |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupIncident(\ ``Integer uniqueId``, ``Integer incidentId``)                                  |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupIncident(\ ``Integer uniqueId``, ``Integer incidentId``, ``String ownerName``)            |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupSignatures(\ ``Integer uniqueId``, ``List<Integer> signatureIds``)                        |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupSignatures(\ ``Integer uniqueId``, ``List<Integer> signatureIds``, ``String ownerName``)  |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupSignature(\ ``Integer uniqueId``, ``Integer signatureId``)                                |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupSignature(\ ``Integer uniqueId``, ``Integer signatureId``, ``String ownerName``)          |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupThreats(\ ``Integer uniqueId``, ``List<Integer> threatIds``)                              |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateGroupThreats(\ ``Integer uniqueId``, ``List<Integer> threatIds``, ``String ownerName``)        |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupThreat(\ ``Integer uniqueId``, ``Integer threatId``)                                      |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateGroupThreat(\ ``Integer uniqueId``, ``Integer threatId``, ``String ownerName``)                |
++--------------------------------+---------------------------------------------------------------------------------------------------------+
 
 Associate Indicators
 ~~~~~~~~~~~~~~~~~~~~
 
 The methods below associate Indicators to a Group type.
 
-+--------------------+---------------------------------------------------------+
-| Type               | *Method*                                                |
-+====================+=========================================================+
-| ``WriteListRespons | associateIndicatorAddresses(\ ``Integer uniqueId``,     |
-| e<String>``        | ``List<String> ipAddresses``)                           |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorAddresses(\ ``Integer uniqueId``,     |
-| e<String>``        | ``List<String> ipAddresses``, ``String ownerName``)     |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorAddress(\ ``Integer uniqueId``,       |
-| esponse``          | ``String ipAddress``)                                   |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorAddress(\ ``Integer uniqueId``,       |
-| esponse``          | ``String ipAddress``, ``String ownerName``)             |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorEmailAddresses(\ ``Integer uniqueId`` |
-| e<String>``        | ,                                                       |
-|                    | ``List<String> emailAddresses``)                        |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorEmailAddresses(\ ``Integer uniqueId`` |
-| e<String>``        | ,                                                       |
-|                    | ``List<String> emailAddresses``,                        |
-|                    | ``String ownerName``)                                   |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorEmailAddress(\ ``Integer uniqueId``   |
-| esponse``          | ,                                                       |
-|                    | ``String emailAddress``)                                |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorEmailAddress(\ ``Integer uniqueId``   |
-| esponse``          | ,                                                       |
-|                    | ``String emailAddress``, ``String ownerName``)          |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorFiles(\ ``Integer uniqueId``,         |
-| e<String>``        | ``List<String> fileHashes``)                            |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorFiles(\ ``Integer uniqueId``,         |
-| e<String>``        | ``List<String> fileHashes``, ``String ownerName``)      |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorFile(\ ``Integer uniqueId``,          |
-| esponse``          | ``String fileHash``)                                    |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorFile(\ ``Integer uniqueId``,          |
-| esponse``          | ``String fileHash``, ``String ownerName``)              |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorHosts(\ ``Integer uniqueId``,         |
-| e<String>``        | ``List<String> hostNames``)                             |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorHosts(\ ``Integer uniqueId``,         |
-| e<String>``        | ``List<String> hostNames``, ``String ownerName``)       |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorHost(\ ``Integer uniqueId``,          |
-| esponse``          | ``String hostName``)                                    |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorHost(\ ``Integer uniqueId``,          |
-| esponse``          | ``String hostName``, ``String ownerName``)              |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorUrls(\ ``Integer uniqueId``,          |
-| e<String>``        | ``List<String> urlTexts``)                              |
-+--------------------+---------------------------------------------------------+
-| ``WriteListRespons | associateIndicatorUrls(\ ``Integer uniqueId``,          |
-| e<String>``        | ``List<String> urlTexts``, ``String ownerName``)        |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorUrl(\ ``Integer uniqueId``,           |
-| esponse``          | ``String urlText``)                                     |
-+--------------------+---------------------------------------------------------+
-| ``ApiEntitySingleR | associateIndicatorUrl(\ ``Integer uniqueId``,           |
-| esponse``          | ``String urlText``, ``String ownerName``)               |
-+--------------------+---------------------------------------------------------+
++-------------------------------+---------------------------------------------------------------------------------+
+| Type                          | Method                                                                          |
++===============================+=================================================================================+
+| ``WriteListResponse<String>`` | associateIndicatorAddresses(\ ``Integer uniqueId``,                             |
+|                               | ``List<String> ipAddresses``)                                                   |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorAddresses(\ ``Integer uniqueId``,                             |
+|                               | ``List<String> ipAddresses``, ``String ownerName``)                             |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorAddress(\ ``Integer uniqueId``, ``String ipAddress``)         |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorAddress(\ ``Integer uniqueId``, ``String ipAddress``,         |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorEmailAddresses(\ ``Integer uniqueId``,                        |
+|                               | ``List<String> emailAddresses``)                                                |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorEmailAddresses(\ ``Integer uniqueId``,                        |
+|                               | ``List<String> emailAddresses``, ``String ownerName``)                          |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorEmailAddress(\ ``Integer uniqueId``, ``String emailAddress``) |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorEmailAddress(\ ``Integer uniqueId``, ``String emailAddress``, |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorFiles(\ ``Integer uniqueId``, ``List<String> fileHashes``)    |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorFiles(\ ``Integer uniqueId``, ``List<String> fileHashes``,    |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorFile(\ ``Integer uniqueId``, ``String fileHash``)             |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorFile(\ ``Integer uniqueId``, ``String fileHash``,             |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorHosts(\ ``Integer uniqueId``, ``List<String> hostNames``)     |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorHosts(\ ``Integer uniqueId``, ``List<String> hostNames``,     |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorHost(\ ``Integer uniqueId``, ``String hostName``)             |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorHost(\ ``Integer uniqueId``, ``String hostName``,             |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorUrls(\ ``Integer uniqueId``, ``List<String> urlTexts``)       |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateIndicatorUrls(\ ``Integer uniqueId``, ``List<String> urlTexts``,       |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorUrl(\ ``Integer uniqueId``, ``String urlText``)               |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateIndicatorUrl(\ ``Integer uniqueId``, ``String urlText``,               |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+
 
 Associate Security Labels
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The methods below associate Security Labels to a Group type.
 
-+---------------------+------------------------------------------------------+
-| Type                | *Method*                                             |
-+=====================+======================================================+
-| ``WriteListResponse | associateSecurityLabels(\ ``Integer uniqueId``,      |
-| <String>``          | ``List<String> securityLabels``)                     |
-+---------------------+------------------------------------------------------+
-| ``WriteListResponse | associateSecurityLabels(\ ``Integer uniqueId``,      |
-| <String>``          | ``List<String> securityLabels``,                     |
-|                     | ``String ownerName``)                                |
-+---------------------+------------------------------------------------------+
-| ``ApiEntitySingleRe | associateSecurityLabel(\ ``Integer uniqueId``,       |
-| sponse``            | ``String securityLabel``)                            |
-+---------------------+------------------------------------------------------+
-| ``ApiEntitySingleRe | associateSecurityLabel(\ ``Integer uniqueId``,       |
-| sponse``            | ``String securityLabel``, ``String ownerName``)      |
-+---------------------+------------------------------------------------------+
++-------------------------------+--------------------------------------------------------------------------------------------------------+
+| Type                          | Method                                                                                                 |
++===============================+========================================================================================================+
+| ``WriteListResponse<String>`` | associateSecurityLabels(\ ``Integer uniqueId``, ``List<String> securityLabels``)                       |
++-------------------------------+--------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateSecurityLabels(\ ``Integer uniqueId``, ``List<String> securityLabels``, ``String ownerName``) |
++-------------------------------+--------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateSecurityLabel(\ ``Integer uniqueId``, ``String securityLabel``)                               |
++-------------------------------+--------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateSecurityLabel(\ ``Integer uniqueId``, ``String securityLabel``, ``String ownerName``)         |
++-------------------------------+--------------------------------------------------------------------------------------------------------+
 
 Associate Tag
 ~~~~~~~~~~~~~
 
 The methods below associate Tags to a Group type.
 
-+--------------------+-------------------------------------------------------+
-| Type               | *Method*                                              |
-+====================+=======================================================+
-| ``WriteListRespons | associateTags(\ ``Integer uniqueId``,                 |
-| e<String>``        | ``List<String> tagNames``)                            |
-+--------------------+-------------------------------------------------------+
-| ``WriteListRespons | associateTags(\ ``Integer uniqueId``,                 |
-| e<String>``        | ``List<String> tagNames``, ``String ownerName``)      |
-+--------------------+-------------------------------------------------------+
-| ``ApiEntitySingleR | associateTag(\ ``Integer uniqueId``,                  |
-| esponse``          | ``String tagName``)                                   |
-+--------------------+-------------------------------------------------------+
-| ``ApiEntitySingleR | associateTag(\ ``Integer uniqueId``,                  |
-| esponse``          | ``String tagName``, ``String ownerName``)             |
-+--------------------+-------------------------------------------------------+
++-------------------------------+----------------------------------------------------------------------------------------+
+| Type                          | Method                                                                                 |
++===============================+========================================================================================+
+| ``WriteListResponse<String>`` | associateTags(\ ``Integer uniqueId``, ``List<String> tagNames``)                       |
++-------------------------------+----------------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | associateTags(\ ``Integer uniqueId``, ``List<String> tagNames``, ``String ownerName``) |
++-------------------------------+----------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateTag(\ ``Integer uniqueId``, ``String tagName``)                               |
++-------------------------------+----------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateTag(\ ``Integer uniqueId``, ``String tagName``, ``String ownerName``)         |
++-------------------------------+----------------------------------------------------------------------------------------+
 
 Associate Victim
 ~~~~~~~~~~~~~~~~
 
 The methods below associate Victims to a Group type.
 
-+---------------------+------------------------------------------------------+
-| Type                | *Method*                                             |
-+=====================+======================================================+
-| ``WriteListResponse | associateVictims(\ ``Integer uniqueId``,             |
-| <Integer>``         | ``List<Integer> victimIds``)                         |
-+---------------------+------------------------------------------------------+
-| ``WriteListResponse | associateVictims(\ ``Integer uniqueId``,             |
-| <Integer>``         | ``List<Integer> victimIds``, ``String ownerName``)   |
-+---------------------+------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictim(\ ``Integer uniqueId``,              |
-| sponse``            | ``Integer victimId``)                                |
-+---------------------+------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictim(\ ``Integer uniqueId``,              |
-| sponse``            | ``Integer victimId``, ``String ownerName``)          |
-+---------------------+------------------------------------------------------+
++--------------------------------+---------------------------------------------------------------------------------------------+
+| Type                           | Method                                                                                      |
++================================+=============================================================================================+
+| ``WriteListResponse<Integer>`` | associateVictims(\ ``Integer uniqueId``, ``List<Integer> victimIds``)                       |
++--------------------------------+---------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | associateVictims(\ ``Integer uniqueId``, ``List<Integer> victimIds``, ``String ownerName``) |
++--------------------------------+---------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateVictim(\ ``Integer uniqueId``, ``Integer victimId``)                               |
++--------------------------------+---------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | associateVictim(\ ``Integer uniqueId``, ``Integer victimId``, ``String ownerName``)         |
++--------------------------------+---------------------------------------------------------------------------------------------+
 
 Associate Victim Asset
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The methods below associate Victim Assets to a Group type.
 
-+---------------------+-----------------------------------------------------------+
-| Type                | *Method*                                                  |
-+=====================+===========================================================+
-| ``WriteListResponse | associateVictimAssetEmailAddresses(\ ``Integer uniqu      |
-| <Integer>``         | eId``,                                                    |
-|                     | ``List<Integer> assetIds``)                               |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetEmailAddresses(\ ``Integer uniqu      |
-| <Integer>``         | eId``,                                                    |
-|                     | ``List<Integer> assetIds``, ``String ownerName``)         |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetEmailAddress(\ ``Integer uniqueI      |
-| sponse``            | d``,                                                      |
-|                     | ``Integer assetId``)                                      |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetEmailAddress(\ ``Integer uniqueI      |
-| sponse``            | d``,                                                      |
-|                     | ``Integer assetId``, ``String ownerName``)                |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetNetworkAccounts(\ ``Integer uniq      |
-| <Integer>``         | ueId``,                                                   |
-|                     | ``List<Integer> assetIds``)                               |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetNetworkAccounts(\ ``Integer uniq      |
-| <Integer>``         | ueId``,                                                   |
-|                     | ``List<Integer> assetIds``, ``String ownerName``)         |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetNetworkAccount(\ ``Integer uniqu      |
-| sponse``            | eId``,                                                    |
-|                     | ``Integer assetId``)                                      |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetNetworkAccount(\ ``Integer uniqu      |
-| sponse``            | eId``,                                                    |
-|                     | ``Integer assetId``, ``String ownerName``)                |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetPhoneNumbers(\ ``Integer uniqueId``   |
-| <Integer>``         | ,                                                         |
-|                     | ``List<Integer> assetIds``)                               |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetPhoneNumbers(\ ``Integer uniqueId``   |
-| <Integer>``         | ,                                                         |
-|                     | ``List<Integer> assetIds``, ``String ownerName``)         |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetPhoneNumber(\ ``Integer uniqueId``    |
-| sponse``            | ,                                                         |
-|                     | ``Integer assetId``)                                      |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetPhoneNumber(\ ``Integer uniqueId``    |
-| sponse``            | ,                                                         |
-|                     | ``Integer assetId``, ``String ownerName``)                |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetSocialNetworks(\ ``Integer uniqueId`` |
-| <Integer>``         | ,                                                         |
-|                     | ``List<Integer> assetIds``)                               |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetSocialNetworks(\ ``Integer uniqueId`` |
-| <Integer>``         | ,                                                         |
-|                     | ``List<Integer> assetIds``, ``String ownerName``)         |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetSocialNetwork(\ ``Integer uniqueId``  |
-| sponse``            | ,                                                         |
-|                     | ``Integer assetId``)                                      |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetSocialNetwork(\ ``Integer uniqueId``  |
-| sponse``            | ,                                                         |
-|                     | ``Integer assetId``, ``String ownerName``)                |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetWebsites(\ ``Integer uniqueId``,      |
-| <Integer>``         | ``List<Integer> assetIds``)                               |
-+---------------------+-----------------------------------------------------------+
-| ``WriteListResponse | associateVictimAssetWebsites(\ ``Integer uniqueId``,      |
-| <Integer>``         | ``List<Integer> assetIds``, ``String ownerName``)         |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetWebsite(\ ``Integer uniqueId``,       |
-| sponse``            | ``Integer assetId``)                                      |
-+---------------------+-----------------------------------------------------------+
-| ``ApiEntitySingleRe | associateVictimAssetWebsite(\ ``Integer uniqueId``,       |
-| sponse``            | ``Integer assetId``, ``String ownerName``)                |
-+---------------------+-----------------------------------------------------------+
++-------------------------------+---------------------------------------------------------------------------------+
+| Type                          | Method                                                                          |
++===============================+=================================================================================+
+| ``WriteListResponse<Integer>` | associateVictimAssetEmailAddresses(\ ``Integer uniqueId``,                      |
+| `                             | ``List<Integer> assetIds``)                                                     |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetEmailAddresses(\ ``Integer uniqueId``,                      |
+| `                             | ``List<Integer> assetIds``, ``String ownerName``)                               |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetEmailAddress(\ ``Integer uniqueId``, ``Integer assetId``)   |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetEmailAddress(\ ``Integer uniqueId``, ``Integer assetId``,   |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetNetworkAccounts(\ ``Integer uniqueId``,                     |
+| `                             | ``List<Integer> assetIds``)                                                     |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetNetworkAccounts(\ ``Integer uniqueId``,                     |
+| `                             | ``List<Integer> assetIds``, ``String ownerName``)                               |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetNetworkAccount(\ ``Integer uniqueId``, ``Integer assetId``) |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetNetworkAccount(\ ``Integer uniqueId``, ``Integer assetId``, |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetPhoneNumbers(\ ``Integer uniqueId``,                        |
+| `                             | ``List<Integer> assetIds``)                                                     |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetPhoneNumbers(\ ``Integer uniqueId``,                        |
+| `                             | ``List<Integer> assetIds``, ``String ownerName``)                               |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetPhoneNumber(\ ``Integer uniqueId``, ``Integer assetId``)    |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetPhoneNumber(\ ``Integer uniqueId``, ``Integer assetId``,    |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetSocialNetworks(\ ``Integer uniqueId``,                      |
+| `                             | ``List<Integer> assetIds``)                                                     |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetSocialNetworks(\ ``Integer uniqueId``,                      |
+| `                             | ``List<Integer> assetIds``, ``String ownerName``)                               |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetSocialNetwork(\ ``Integer uniqueId``, ``Integer assetId``)  |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetSocialNetwork(\ ``Integer uniqueId``, ``Integer assetId``,  |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetWebsites(\ ``Integer uniqueId``,                            |
+| `                             | ``List<Integer> assetIds``)                                                     |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>` | associateVictimAssetWebsites(\ ``Integer uniqueId``,                            |
+| `                             | ``List<Integer> assetIds``, ``String ownerName``)                               |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetWebsite(\ ``Integer uniqueId``, ``Integer assetId``)        |
++-------------------------------+---------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | associateVictimAssetWebsite(\ ``Integer uniqueId``, ``Integer assetId``,        |
+|                               | ``String ownerName``)                                                           |
++-------------------------------+---------------------------------------------------------------------------------+
 
 Add Attributes
 ~~~~~~~~~~~~~~
 
 The methods below add Attribute types to a Group.
 
-+----------------------+-----------------------------------------------------+
-| Type                 | *Method*                                            |
-+======================+=====================================================+
-| ``WriteListResponse< | addAttributes(\ ``Integer uniqueId``,               |
-| Attribute>``         | ``List<Attribute> attributes``)                     |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | addAttributes(\ ``Integer uniqueId``,               |
-| Attribute>``         | ``List<Attribute> attribute``,                      |
-|                      | ``String ownerName``)                               |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | addAttribute(\ ``Integer uniqueId``,                |
-| ponse``              | ``Attribute attribute``)                            |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | addAttribute(\ ``Integer uniqueId``,                |
-| ponse``              | ``Attribute attribute``, ``String ownerName``)      |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | addAttributeSecurityLabels(\ ``Integer uniqueId``,  |
-| String>``            | ``Integer attributeId``,                            |
-|                      | ``List<String> securityLabels``)                    |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | addAttributeSecurityLabels(\ ``Integer uniqueId``,  |
-| String>``            | ``Integer attributeId``,                            |
-|                      | ``List<String> securityLabels``,                    |
-|                      | ``String ownerName``)                               |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | addAttributeSecurityLabel(\ ``Integer uniqueId``,   |
-| ponse``              | ``Integer attributeId``, ``String securityLabel``)  |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | addAttributeSecurityLabel(\ ``Integer uniqueId``,   |
-| ponse``              | ``Integer attributeId``, ``String securityLabel``,  |
-|                      | ``String ownerName``)                               |
-+----------------------+-----------------------------------------------------+
++---------------------------------+-----------------------------------------------------------------------------+
+| Type                            | Method                                                                      |
++=================================+=============================================================================+
+| ``WriteListResponse<Attribute>` | addAttributes(\ ``Integer uniqueId``, ``List<Attribute> attributes``)       |
+| `                               |                                                                             |
++---------------------------------+-----------------------------------------------------------------------------+
+| ``WriteListResponse<Attribute>` | addAttributes(\ ``Integer uniqueId``, ``List<Attribute> attribute``,        |
+| `                               | ``String ownerName``)                                                       |
++---------------------------------+-----------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``     | addAttribute(\ ``Integer uniqueId``, ``Attribute attribute``)               |
++---------------------------------+-----------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``     | addAttribute(\ ``Integer uniqueId``, ``Attribute attribute``,               |
+|                                 | ``String ownerName``)                                                       |
++---------------------------------+-----------------------------------------------------------------------------+
+| ``WriteListResponse<String>``   | addAttributeSecurityLabels(\ ``Integer uniqueId``, ``Integer attributeId``, |
+|                                 | ``List<String> securityLabels``)                                            |
++---------------------------------+-----------------------------------------------------------------------------+
+| ``WriteListResponse<String>``   | addAttributeSecurityLabels(\ ``Integer uniqueId``, ``Integer attributeId``, |
+|                                 | ``List<String> securityLabels``, ``String ownerName``)                      |
++---------------------------------+-----------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``     | addAttributeSecurityLabel(\ ``Integer uniqueId``, ``Integer attributeId``,  |
+|                                 | ``String securityLabel``)                                                   |
++---------------------------------+-----------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``     | addAttributeSecurityLabel(\ ``Integer uniqueId``, ``Integer attributeId``,  |
+|                                 | ``String securityLabel``, ``String ownerName``)                             |
++---------------------------------+-----------------------------------------------------------------------------+
 
 Update Attribute
 ~~~~~~~~~~~~~~~~
 
-The methods below **update** an Attribute added to a specific Indicator
-type.
+The methods below **update** an Attribute added to a specific Indicator type.
 
-+-----------------------+----------------------------------------------------+
-| Type                  | *Method*                                           |
-+=======================+====================================================+
-| ``WriteListResponse<A | updateAttributes(\ ``Integer uniqueId``,           |
-| ttribute>``           | ``List<Attribute> attributes``)                    |
-+-----------------------+----------------------------------------------------+
-| ``WriteListResponse<A | updateAttributes(\ ``Integer uniqueId``,           |
-| ttribute>``           | ``List<Attribute> attribute``,                     |
-|                       | ``String ownerName``)                              |
-+-----------------------+----------------------------------------------------+
-| ``ApiEntitySingleResp | updateAttribute(\ ``Integer uniqueId``,            |
-| onse``                | ``Attribute attribute``)                           |
-+-----------------------+----------------------------------------------------+
-| ``ApiEntitySingleResp | updateAttribute(\ ``Integer uniqueId``,            |
-| onse``                | ``Attribute attribute``, ``String ownerName``)     |
-+-----------------------+----------------------------------------------------+
++----------------------------------+-----------------------------------------------------------------------------------------------+
+| Type                             | Method                                                                                        |
++==================================+===============================================================================================+
+| ``WriteListResponse<Attribute>`` | updateAttributes(\ ``Integer uniqueId``, ``List<Attribute> attributes``)                      |
++----------------------------------+-----------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Attribute>`` | updateAttributes(\ ``Integer uniqueId``, ``List<Attribute> attribute``, ``String ownerName``) |
++----------------------------------+-----------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``      | updateAttribute(\ ``Integer uniqueId``, ``Attribute attribute``)                              |
++----------------------------------+-----------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``      | updateAttribute(\ ``Integer uniqueId``, ``Attribute attribute``, ``String ownerName``)        |
++----------------------------------+-----------------------------------------------------------------------------------------------+
 
 Create Observation
 ~~~~~~~~~~~~~~~~~~
 
-The methods below **create** an Observation on a specific Indicator
-type.
+The methods below **create** an Observation on a specific Indicator type.
 
-+--------------------+-------------------------------------------------------+
-| Type               | *Method*                                              |
-+====================+=======================================================+
-| ``ApiEntitySingleR | createObservation(\ ``Integer uniqueId``)             |
-| esponse``          |                                                       |
-+--------------------+-------------------------------------------------------+
-| ``ApiEntitySingleR | createObservation(\ ``Integer uniqueId``,             |
-| esponse``          | ``String ownerName``)                                 |
-+--------------------+-------------------------------------------------------+
++-----------------------------+-----------------------------------------------------------------+
+| Type                        | Method                                                          |
++=============================+=================================================================+
+| ``ApiEntitySingleResponse`` | createObservation(\ ``Integer uniqueId``)                       |
++-----------------------------+-----------------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | createObservation(\ ``Integer uniqueId``, ``String ownerName``) |
++-----------------------------+-----------------------------------------------------------------+
 
 Update False Positive
 ~~~~~~~~~~~~~~~~~~~~~
 
-The methods below **update** the False Positive field on a specific
-Indicator type.
+The methods below **update** the False Positive field on a specific Indicator type.
 
-+--------------------+--------------------------------------------------------+
-| Type               | *Method*                                               |
-+====================+========================================================+
-| ``ApiEntitySingleR | updateFalsePositive(\ ``Integer uniqueId``)            |
-| esponse``          |                                                        |
-+--------------------+--------------------------------------------------------+
-| ``ApiEntitySingleR | updateFalsePositive(\ ``Integer uniqueId``,            |
-| esponse``          | ``String ownerName``)                                  |
-+--------------------+--------------------------------------------------------+
++-----------------------------+-------------------------------------------------------------------+
+| Type                        | Method                                                            |
++=============================+===================================================================+
+| ``ApiEntitySingleResponse`` | updateFalsePositive(\ ``Integer uniqueId``)                       |
++-----------------------------+-------------------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | updateFalsePositive(\ ``Integer uniqueId``, ``String ownerName``) |
++-----------------------------+-------------------------------------------------------------------+
 
 Delete Group Association
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The methods below **delete** Group associations to a specific Group
-type.
+The methods below **delete** Group associations to a specific Group type.
 
-+----------------------+------------------------------------------------------+
-| Type                 | *Method*                                             |
-+======================+======================================================+
-| ``WriteListResponse< | dissociateGroupAdversaries(\ ``Integer uniqueId``,   |
-| Integer>``           | ``List<Integer> adversaryIds``)                      |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupAdversaries(\ ``Integer uniqueId``,   |
-| Integer>``           | ``List<Integer> adversaryIds``,                      |
-|                      | ``String ownerName``)                                |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupAdversary(\ ``Integer uniqueId``,     |
-| ponse``              | ``Integer adversaryId``)                             |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupAdversary(\ ``Integer uniqueId``,     |
-| ponse``              | ``Integer adversaryId``, ``String ownerName``)       |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupEmails(\ ``Integer uniqueId``,        |
-| Integer>``           | ``List<Integer> emailIds``)                          |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupEmails(\ ``Integer uniqueId``,        |
-| Integer>``           | ``List<Integer> emailIds``, ``String ownerName``)    |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupEmail(\ ``Integer uniqueId``,         |
-| ponse``              | ``Integer emailId``)                                 |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupEmail(\ ``Integer uniqueId``,         |
-| ponse``              | ``Integer emailId``, ``String ownerName``)           |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupIncidents(\ ``Integer uniqueId``,     |
-| Integer>``           | ``List<Integer> incidentIds``)                       |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupIncidents(\ ``Integer uniqueId``,     |
-| Integer>``           | ``List<Integer> incidentIds``, ``String ownerName``) |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupIncident(\ ``Integer uniqueId``,      |
-| ponse``              | ``Integer incidentId``)                              |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupIncident(\ ``Integer uniqueId``,      |
-| ponse``              | ``Integer incidentId``, ``String ownerName``)        |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupSignatures(\ ``Integer uniqueId``,    |
-| Integer>``           | ``List<Integer> signatureIds``)                      |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupSignatures(\ ``Integer uniqueId``,    |
-| Integer>``           | ``List<Integer> signatureIds``,                      |
-|                      | ``String ownerName``)                                |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupSignature(\ ``Integer uniqueId``,     |
-| ponse``              | ``Integer signatureId``)                             |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupSignature(\ ``Integer uniqueId``,     |
-| ponse``              | ``Integer signatureId``, ``String ownerName``)       |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupThreats(\ ``Integer uniqueId``,       |
-| Integer>``           | ``List<Integer> threatIds``)                         |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateGroupThreats(\ ``Integer uniqueId``,       |
-| Integer>``           | ``List<Integer> threatIds``, ``String ownerName``)   |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupThreat(\ ``Integer uniqueId``,        |
-| ponse``              | ``Integer threatId``)                                |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateGroupThreat(\ ``Integer uniqueId``,        |
-| ponse``              | ``Integer threatId``, ``String ownerName``)          |
-+----------------------+------------------------------------------------------+
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| Type                           | Method                                                                                                   |
++================================+==========================================================================================================+
+| ``WriteListResponse<Integer>`` | dissociateGroupAdversaries(\ ``Integer uniqueId``, ``List<Integer> adversaryIds``)                       |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupAdversaries(\ ``Integer uniqueId``, ``List<Integer> adversaryIds``, ``String ownerName``) |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupAdversary(\ ``Integer uniqueId``, ``Integer adversaryId``)                                |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupAdversary(\ ``Integer uniqueId``, ``Integer adversaryId``, ``String ownerName``)          |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupEmails(\ ``Integer uniqueId``, ``List<Integer> emailIds``)                                |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupEmails(\ ``Integer uniqueId``, ``List<Integer> emailIds``, ``String ownerName``)          |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupEmail(\ ``Integer uniqueId``, ``Integer emailId``)                                        |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupEmail(\ ``Integer uniqueId``, ``Integer emailId``, ``String ownerName``)                  |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupIncidents(\ ``Integer uniqueId``, ``List<Integer> incidentIds``)                          |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupIncidents(\ ``Integer uniqueId``, ``List<Integer> incidentIds``, ``String ownerName``)    |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupIncident(\ ``Integer uniqueId``, ``Integer incidentId``)                                  |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupIncident(\ ``Integer uniqueId``, ``Integer incidentId``, ``String ownerName``)            |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupSignatures(\ ``Integer uniqueId``, ``List<Integer> signatureIds``)                        |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupSignatures(\ ``Integer uniqueId``, ``List<Integer> signatureIds``, ``String ownerName``)  |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupSignature(\ ``Integer uniqueId``, ``Integer signatureId``)                                |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupSignature(\ ``Integer uniqueId``, ``Integer signatureId``, ``String ownerName``)          |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupThreats(\ ``Integer uniqueId``, ``List<Integer> threatIds``)                              |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateGroupThreats(\ ``Integer uniqueId``, ``List<Integer> threatIds``, ``String ownerName``)        |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupThreat(\ ``Integer uniqueId``, ``Integer threatId``)                                      |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateGroupThreat(\ ``Integer uniqueId``, ``Integer threatId``, ``String ownerName``)                |
++--------------------------------+----------------------------------------------------------------------------------------------------------+
 
 Delete Indicator Associations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The methods below **delete** Indicator associations to a specific Group
-type.
+The methods below **delete** Indicator associations to a specific Group type.
 
-+----------------------+-----------------------------------------------------+
-| Type                 | *Method*                                            |
-+======================+=====================================================+
-| ``WriteListResponse< | dissociateIndicatorAddresses(\ ``Integer uniqueId`` |
-| String>``            | ,                                                   |
-|                      | ``List<String> ipAddresses``)                       |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorAddresses(\ ``Integer uniqueId`` |
-| String>``            | ,                                                   |
-|                      | ``List<String> ipAddresses``, ``String ownerName``) |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorAddress(\ ``Integer uniqueId``,  |
-| ponse``              | ``String ipAddress``)                               |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorAddress(\ ``Integer uniqueId``,  |
-| ponse``              | ``String ipAddress``, ``String ownerName``)         |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorEmailAddresses(\ ``Integer uniqu |
-| String>``            | eId``,                                              |
-|                      | ``List<String> emailAddresses``)                    |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorEmailAddresses(\ ``Integer uniqu |
-| String>``            | eId``,                                              |
-|                      | ``List<String> emailAddresses``,                    |
-|                      | ``String ownerName``)                               |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorEmailAddress(\ ``Integer uniqueI |
-| ponse``              | d``,                                                |
-|                      | ``String emailAddress``)                            |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorEmailAddress(\ ``Integer uniqueI |
-| ponse``              | d``,                                                |
-|                      | ``String emailAddress``, ``String ownerName``)      |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorFiles(\ ``Integer uniqueId``,    |
-| String>``            | ``List<String> fileHashes``)                        |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorFiles(\ ``Integer uniqueId``,    |
-| String>``            | ``List<String> fileHashes``, ``String ownerName``)  |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorFile(\ ``Integer uniqueId``,     |
-| ponse``              | ``String fileHash``)                                |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorFile(\ ``Integer uniqueId``,     |
-| ponse``              | ``String fileHash``, ``String ownerName``)          |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorHosts(\ ``Integer uniqueId``,    |
-| String>``            | ``List<String> hostNames``)                         |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorHosts(\ ``Integer uniqueId``,    |
-| String>``            | ``List<String> hostNames``, ``String ownerName``)   |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorHost(\ ``Integer uniqueId``,     |
-| ponse``              | ``String hostName``)                                |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorHost(\ ``Integer uniqueId``,     |
-| ponse``              | ``String hostName``, ``String ownerName``)          |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorUrls(\ ``Integer uniqueId``,     |
-| String>``            | ``List<String> urlTexts``)                          |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateIndicatorUrls(\ ``Integer uniqueId``,     |
-| String>``            | ``List<String> urlTexts``, ``String ownerName``)    |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorUrl(\ ``Integer uniqueId``,      |
-| ponse``              | ``String urlText``)                                 |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateIndicatorUrl(\ ``Integer uniqueId``,      |
-| ponse``              | ``String urlText``, ``String ownerName``)           |
-+----------------------+-----------------------------------------------------+
++-------------------------------+-------------------------------------------------------------------------------+
+| Type                          | Method                                                                        |
++===============================+===============================================================================+
+| ``WriteListResponse<String>`` | dissociateIndicatorAddresses(\ ``Integer uniqueId``,                          |
+|                               | ``List<String> ipAddresses``)                                                 |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorAddresses(\ ``Integer uniqueId``,                          |
+|                               | ``List<String> ipAddresses``, ``String ownerName``)                           |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorAddress(\ ``Integer uniqueId``, ``String ipAddress``)      |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorAddress(\ ``Integer uniqueId``, ``String ipAddress``,      |
+|                               | ``String ownerName``)                                                         |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorEmailAddresses(\ ``Integer uniqueId``,                     |
+|                               | ``List<String> emailAddresses``)                                              |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorEmailAddresses(\ ``Integer uniqueId``,                     |
+|                               | ``List<String> emailAddresses``, ``String ownerName``)                        |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorEmailAddress(\ ``Integer uniqueId``,                       |
+|                               | ``String emailAddress``)                                                      |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorEmailAddress(\ ``Integer uniqueId``,                       |
+|                               | ``String emailAddress``, ``String ownerName``)                                |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorFiles(\ ``Integer uniqueId``, ``List<String> fileHashes``) |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorFiles(\ ``Integer uniqueId``, ``List<String> fileHashes``, |
+|                               | ``String ownerName``)                                                         |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorFile(\ ``Integer uniqueId``, ``String fileHash``)          |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorFile(\ ``Integer uniqueId``, ``String fileHash``,          |
+|                               | ``String ownerName``)                                                         |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorHosts(\ ``Integer uniqueId``, ``List<String> hostNames``)  |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorHosts(\ ``Integer uniqueId``, ``List<String> hostNames``,  |
+|                               | ``String ownerName``)                                                         |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorHost(\ ``Integer uniqueId``, ``String hostName``)          |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorHost(\ ``Integer uniqueId``, ``String hostName``,          |
+|                               | ``String ownerName``)                                                         |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorUrls(\ ``Integer uniqueId``, ``List<String> urlTexts``)    |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateIndicatorUrls(\ ``Integer uniqueId``, ``List<String> urlTexts``,    |
+|                               | ``String ownerName``)                                                         |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorUrl(\ ``Integer uniqueId``, ``String urlText``)            |
++-------------------------------+-------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateIndicatorUrl(\ ``Integer uniqueId``, ``String urlText``,            |
+|                               | ``String ownerName``)                                                         |
++-------------------------------+-------------------------------------------------------------------------------+
 
 Delete Security Label Associations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The methods below **delete** SecurityLabel associations to a specific
-Group type.
+The methods below **delete** SecurityLabel associations to a specific Group type.
 
-+---------------------+------------------------------------------------------+
-| Type                | *Method*                                             |
-+=====================+======================================================+
-| ``WriteListResponse | dissociateSecurityLabel(\ ``Integer uniqueId``,      |
-| <String>``          | ``List<String> securityLabels``)                     |
-+---------------------+------------------------------------------------------+
-| ``WriteListResponse | dissociateSecurityLabel(\ ``Integer uniqueId``,      |
-| <String>``          | ``List<String> securityLabels``,                     |
-|                     | ``String ownerName``)                                |
-+---------------------+------------------------------------------------------+
-| ``ApiEntitySingleRe | dissociateSecurityLabel(\ ``Integer uniqueId``,      |
-| sponse``            | ``String securityLabel``)                            |
-+---------------------+------------------------------------------------------+
-| ``ApiEntitySingleRe | dissociateSecurityLabel(\ ``Integer uniqueId``,      |
-| sponse``            | ``String securityLabel``, ``String ownerName``)      |
-+---------------------+------------------------------------------------------+
++-------------------------------+--------------------------------------------------------------------------------------------------------+
+| Type                          | Method                                                                                                 |
++===============================+========================================================================================================+
+| ``WriteListResponse<String>`` | dissociateSecurityLabel(\ ``Integer uniqueId``, ``List<String> securityLabels``)                       |
++-------------------------------+--------------------------------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateSecurityLabel(\ ``Integer uniqueId``, ``List<String> securityLabels``, ``String ownerName``) |
++-------------------------------+--------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateSecurityLabel(\ ``Integer uniqueId``, ``String securityLabel``)                              |
++-------------------------------+--------------------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateSecurityLabel(\ ``Integer uniqueId``, ``String securityLabel``, ``String ownerName``)        |
++-------------------------------+--------------------------------------------------------------------------------------------------------+
 
 Delete Tag Associations
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The methods below **delete** Tag associations to a specific Group type.
 
-+---------------------+------------------------------------------------------+
-| Type                | *Method*                                             |
-+=====================+======================================================+
-| ``WriteListResponse | dissociateTags(\ ``Integer uniqueId``,               |
-| <String>``          | ``List<String> tagNames``)                           |
-+---------------------+------------------------------------------------------+
-| ``WriteListResponse | dissociateTags(\ ``Integer uniqueId``,               |
-| <String>``          | ``List<String> tagNames``, ``String ownerName``)     |
-+---------------------+------------------------------------------------------+
-| ``ApiEntitySingleRe | dissociateTag(\ ``Integer uniqueId``,                |
-| sponse``            | ``String tagName``)                                  |
-+---------------------+------------------------------------------------------+
-| ``ApiEntitySingleRe | dissociateTag(\ ``Integer uniqueId``,                |
-| sponse``            | ``String tagName``, ``String ownerName``)            |
-+---------------------+------------------------------------------------------+
++-------------------------------+-----------------------------------------------------------------------------------------+
+| Type                          | Method                                                                                  |
++===============================+=========================================================================================+
+| ``WriteListResponse<String>`` | dissociateTags(\ ``Integer uniqueId``, ``List<String> tagNames``)                       |
++-------------------------------+-----------------------------------------------------------------------------------------+
+| ``WriteListResponse<String>`` | dissociateTags(\ ``Integer uniqueId``, ``List<String> tagNames``, ``String ownerName``) |
++-------------------------------+-----------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateTag(\ ``Integer uniqueId``, ``String tagName``)                               |
++-------------------------------+-----------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``   | dissociateTag(\ ``Integer uniqueId``, ``String tagName``, ``String ownerName``)         |
++-------------------------------+-----------------------------------------------------------------------------------------+
 
 Delete Victim Associations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The methods below **delete** Victim associations to a specific Group
-type.
+The methods below **delete** Victim associations to a specific Group type.
 
-+----------------------+-----------------------------------------------------+
-| Type                 | *Method*                                            |
-+======================+=====================================================+
-| ``WriteListResponse< | dissociateVictims(\ ``Integer uniqueId``,           |
-| Integer>``           | ``List<Integer> victimIds``)                        |
-+----------------------+-----------------------------------------------------+
-| ``WriteListResponse< | dissociateVictims(\ ``Integer uniqueId``,           |
-| Integer>``           | ``List<Integer> victimIds``, ``String ownerName``)  |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictim(\ ``Integer uniqueId``,            |
-| ponse``              | ``Integer victimId``)                               |
-+----------------------+-----------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictim(\ ``Integer uniqueId``,            |
-| ponse``              | ``Integer victimId``, ``String ownerName``)         |
-+----------------------+-----------------------------------------------------+
++--------------------------------+----------------------------------------------------------------------------------------------+
+| Type                           | Method                                                                                       |
++================================+==============================================================================================+
+| ``WriteListResponse<Integer>`` | dissociateVictims(\ ``Integer uniqueId``, ``List<Integer> victimIds``)                       |
++--------------------------------+----------------------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictims(\ ``Integer uniqueId``, ``List<Integer> victimIds``, ``String ownerName``) |
++--------------------------------+----------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictim(\ ``Integer uniqueId``, ``Integer victimId``)                               |
++--------------------------------+----------------------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictim(\ ``Integer uniqueId``, ``Integer victimId``, ``String ownerName``)         |
++--------------------------------+----------------------------------------------------------------------------------------------+
 
 Delete VictimAsset Associations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The methods below **delete** VictimAsset associations to a specific
-Group type.
+The methods below **delete** VictimAsset associations to a specific Group type.
 
-+----------------------+------------------------------------------------------+
-| Type                 | *Method*                                             |
-+======================+======================================================+
-| ``WriteListResponse< | dissociateVictimAssetEmailAddresses(\ ``Integer uniq |
-| Integer>``           | ueId``,                                              |
-|                      | ``List<Integer> assetIds``)                          |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetEmailAddresses(\ ``Integer uniq |
-| Integer>``           | ueId``,                                              |
-|                      | ``List<Integer> assetIds``, ``String ownerName``)    |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetEmailAddress(\ ``Integer unique |
-| ponse``              | Id``,                                                |
-|                      | ``Integer assetId``)                                 |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetEmailAddress(\ ``Integer unique |
-| ponse``              | Id``,                                                |
-|                      | ``Integer assetId``, ``String ownerName``)           |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetNetworkAccounts(\ ``Integer uni |
-| Integer>``           | queId``,                                             |
-|                      | ``List<Integer> assetIds``)                          |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetNetworkAccounts(\ ``Integer uni |
-| Integer>``           | queId``,                                             |
-|                      | ``List<Integer> assetIds``, ``String ownerName``)    |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetNetworkAccount(\ ``Integer uniq |
-| ponse``              | ueId``,                                              |
-|                      | ``Integer assetId``)                                 |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetNetworkAccount(\ ``Integer uniq |
-| ponse``              | ueId``,                                              |
-|                      | ``Integer assetId``, ``String ownerName``)           |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetPhoneNumbers(\ ``Integer unique |
-| Integer>``           | Id``,                                                |
-|                      | ``List<Integer> assetIds``)                          |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetPhoneNumbers(\ ``Integer unique |
-| Integer>``           | Id``,                                                |
-|                      | ``List<Integer> assetIds``, ``String ownerName``)    |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetPhoneNumber(\ ``Integer uniqueI |
-| ponse``              | d``,                                                 |
-|                      | ``Integer assetId``)                                 |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetPhoneNumber(\ ``Integer uniqueI |
-| ponse``              | d``,                                                 |
-|                      | ``Integer assetId``, ``String ownerName``)           |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetSocialNetworks(\ ``Integer uniq |
-| Integer>``           | ueId``,                                              |
-|                      | ``List<Integer> assetIds``)                          |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetSocialNetworks(\ ``Integer uniq |
-| Integer>``           | ueId``,                                              |
-|                      | ``List<Integer> assetIds``, ``String ownerName``)    |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetSocialNetwork(\ ``Integer uniqu |
-| ponse``              | eId``,                                               |
-|                      | ``Integer assetId``)                                 |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetSocialNetwork(\ ``Integer uniqu |
-| ponse``              | eId``,                                               |
-|                      | ``Integer assetId``, ``String ownerName``)           |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetWebsites(\ ``Integer uniqueId`` |
-| Integer>``           | ,                                                    |
-|                      | ``List<Integer> assetIds``)                          |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | dissociateVictimAssetWebsites(\ ``Integer uniqueId`` |
-| Integer>``           | ,                                                    |
-|                      | ``List<Integer> assetIds``, ``String ownerName``)    |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetWebsite(\ ``Integer uniqueId``, |
-| ponse``              | ``Integer assetId``)                                 |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | dissociateVictimAssetWebsite(\ ``Integer uniqueId``, |
-| ponse``              | ``Integer assetId``, ``String ownerName``)           |
-+----------------------+------------------------------------------------------+
++--------------------------------+--------------------------------------------------------------------------------+
+| Type                           | Method                                                                         |
++================================+================================================================================+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetEmailAddresses(\ ``Integer uniqueId``,                    |
+|                                | ``List<Integer> assetIds``)                                                    |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetEmailAddresses(\ ``Integer uniqueId``,                    |
+|                                | ``List<Integer> assetIds``, ``String ownerName``)                              |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetEmailAddress(\ ``Integer uniqueId``, ``Integer assetId``) |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetEmailAddress(\ ``Integer uniqueId``, ``Integer assetId``, |
+|                                | ``String ownerName``)                                                          |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetNetworkAccounts(\ ``Integer uniqueId``,                   |
+|                                | ``List<Integer> assetIds``)                                                    |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetNetworkAccounts(\ ``Integer uniqueId``,                   |
+|                                | ``List<Integer> assetIds``, ``String ownerName``)                              |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetNetworkAccount(\ ``Integer uniqueId``,                    |
+|                                | ``Integer assetId``)                                                           |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetNetworkAccount(\ ``Integer uniqueId``,                    |
+|                                | ``Integer assetId``, ``String ownerName``)                                     |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetPhoneNumbers(\ ``Integer uniqueId``,                      |
+|                                | ``List<Integer> assetIds``)                                                    |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetPhoneNumbers(\ ``Integer uniqueId``,                      |
+|                                | ``List<Integer> assetIds``, ``String ownerName``)                              |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetPhoneNumber(\ ``Integer uniqueId``, ``Integer assetId``)  |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetPhoneNumber(\ ``Integer uniqueId``, ``Integer assetId``,  |
+|                                | ``String ownerName``)                                                          |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetSocialNetworks(\ ``Integer uniqueId``,                    |
+|                                | ``List<Integer> assetIds``)                                                    |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetSocialNetworks(\ ``Integer uniqueId``,                    |
+|                                | ``List<Integer> assetIds``, ``String ownerName``)                              |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetSocialNetwork(\ ``Integer uniqueId``,                     |
+|                                | ``Integer assetId``)                                                           |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetSocialNetwork(\ ``Integer uniqueId``,                     |
+|                                | ``Integer assetId``, ``String ownerName``)                                     |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetWebsites(\ ``Integer uniqueId``,                          |
+|                                | ``List<Integer> assetIds``)                                                    |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | dissociateVictimAssetWebsites(\ ``Integer uniqueId``,                          |
+|                                | ``List<Integer> assetIds``, ``String ownerName``)                              |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetWebsite(\ ``Integer uniqueId``, ``Integer assetId``)      |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | dissociateVictimAssetWebsite(\ ``Integer uniqueId``, ``Integer assetId``,      |
+|                                | ``String ownerName``)                                                          |
++--------------------------------+--------------------------------------------------------------------------------+
 
 Delete Attribute
 ~~~~~~~~~~~~~~~~
 
 The methods below **delete** Attributes from a specific Group type.
 
-+----------------------+------------------------------------------------------+
-| Type                 | *Method*                                             |
-+======================+======================================================+
-| ``WriteListResponse< | deleteAttributes(\ ``Integer uniqueId``,             |
-| Integer>``           | ``List<Integer> attributes``)                        |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | deleteAttributes(\ ``Integer uniqueId``,             |
-| Integer>``           | ``List<Integer> attribute``, ``String ownerName``)   |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | deleteAttribute(\ ``Integer uniqueId``,              |
-| ponse``              | ``Integer attribute``)                               |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | deleteAttribute(\ ``Integer uniqueId``,              |
-| ponse``              | ``Integer attribute``, ``String ownerName``)         |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | deleteAttributeSecurityLabels(\ ``Integer uniqueId`` |
-| String>``            | ,                                                    |
-|                      | ``Integer attributeId``,                             |
-|                      | ``List<String> securityLabels``)                     |
-+----------------------+------------------------------------------------------+
-| ``WriteListResponse< | deleteAttributeSecurityLabels(\ ``Integer uniqueId`` |
-| String>``            | ,                                                    |
-|                      | ``Integer attributeId``,                             |
-|                      | ``List<String> securityLabels``,                     |
-|                      | ``String ownerName``)                                |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | deleteAttributeSecurityLabel(\ ``Integer uniqueId``, |
-| ponse``              | ``Integer attributeId``, ``String securityLabel``)   |
-+----------------------+------------------------------------------------------+
-| ``ApiEntitySingleRes | deleteAttributeSecurityLabel(\ ``Integer uniqueId``, |
-| ponse``              | ``Integer attributeId``, ``String securityLabel``,   |
-|                      | ``String ownerName``)                                |
-+----------------------+------------------------------------------------------+
++--------------------------------+--------------------------------------------------------------------------------+
+| Type                           | Method                                                                         |
++================================+================================================================================+
+| ``WriteListResponse<Integer>`` | deleteAttributes(\ ``Integer uniqueId``, ``List<Integer> attributes``)         |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<Integer>`` | deleteAttributes(\ ``Integer uniqueId``, ``List<Integer> attribute``,          |
+|                                | ``String ownerName``)                                                          |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | deleteAttribute(\ ``Integer uniqueId``, ``Integer attribute``)                 |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | deleteAttribute(\ ``Integer uniqueId``, ``Integer attribute``,                 |
+|                                | ``String ownerName``)                                                          |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<String>``  | deleteAttributeSecurityLabels(\ ``Integer uniqueId``, ``Integer attributeId``, |
+|                                | ``List<String> securityLabels``)                                               |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``WriteListResponse<String>``  | deleteAttributeSecurityLabels(\ ``Integer uniqueId``, ``Integer attributeId``, |
+|                                | ``List<String> securityLabels``, ``String ownerName``)                         |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | deleteAttributeSecurityLabel(\ ``Integer uniqueId``, ``Integer attributeId``,  |
+|                                | ``String securityLabel``)                                                      |
++--------------------------------+--------------------------------------------------------------------------------+
+| ``ApiEntitySingleResponse``    | deleteAttributeSecurityLabel(\ ``Integer uniqueId``, ``Integer attributeId``,  |
+|                                | ``String securityLabel``, ``String ownerName``)                                |
++--------------------------------+--------------------------------------------------------------------------------+
 
 AbstractIndicatorWriterAdapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2415,44 +2225,38 @@ method-naming conventions are the same.
 FileIndicatorWriterAdapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-FileIndicatorWriterAdapter, which all the functionality of the
-AbstractIndicatorWriterAdapter with the addition of the following write
-methods:
+FileIndicatorWriterAdapter, which all the functionality of the AbstractIndicatorWriterAdapter with the addition of the
+following write methods:
 
-+--------------------------+-------------------------------------------------+
-| Type                     | *Method*                                        |
-+==========================+=================================================+
-| ``WriteListResponse<File | updateFileOccurrences(\ ``String fileHash``,    |
-| Occurrence>``            | ``List<FileOccurrence> fileOccurrences``)       |
-+--------------------------+-------------------------------------------------+
-| ``WriteListResponse<File | updateFileOccurrences(\ ``String fileHash``,    |
-| Occurrence>``            | ``List<FileOccurrence> fileOccurrences``,       |
-|                          | ``String ownerName``)                           |
-+--------------------------+-------------------------------------------------+
-| ``FileOccurrence``       | updateFileOccurrence(\ ``String fileHash``,     |
-|                          | ``FileOccurrence fileOccurrence``)              |
-+--------------------------+-------------------------------------------------+
-| ``FileOccurrence``       | updateFileOccurrence(\ ``String fileHash``,     |
-|                          | ``FileOccurrence fileOccurrence``,              |
-|                          | ``String ownerName``)                           |
-+--------------------------+-------------------------------------------------+
++---------------------------------------+-----------------------------------------------------------------+
+| Type                                  | Method                                                          |
++=======================================+=================================================================+
+| ``WriteListResponse<FileOccurrence>`` | updateFileOccurrences(\ ``String fileHash``,                    |
+|                                       | ``List<FileOccurrence> fileOccurrences``)                       |
++---------------------------------------+-----------------------------------------------------------------+
+| ``WriteListResponse<FileOccurrence>`` | updateFileOccurrences(\ ``String fileHash``,                    |
+|                                       | ``List<FileOccurrence> fileOccurrences``, ``String ownerName``) |
++---------------------------------------+-----------------------------------------------------------------+
+| ``FileOccurrence``                    | updateFileOccurrence(\ ``String fileHash``,                     |
+|                                       | ``FileOccurrence fileOccurrence``)                              |
++---------------------------------------+-----------------------------------------------------------------+
+| ``FileOccurrence``                    | updateFileOccurrence(\ ``String fileHash``,                     |
+|                                       | ``FileOccurrence fileOccurrence``, ``String ownerName``)        |
++---------------------------------------+-----------------------------------------------------------------+
 
 DocumentWriterAdapter
 ~~~~~~~~~~~~~~~~~~~~~
 
-DocumentWriterAdapter has all the functionality of the
-AbstractGroupWriterAdapter with the addition of the following write
-methods:
+DocumentWriterAdapter has all the functionality of the AbstractGroupWriterAdapter with the addition of the following
+write methods:
 
-+-------------------+--------------------------------------------------------+
-| Type              | *Method*                                               |
-+===================+========================================================+
-| ``ApiEntitySingle | uploadFile(\ ``int uniqueId``, ``File file``)          |
-| Response``        |                                                        |
-+-------------------+--------------------------------------------------------+
-| ``ApiEntitySingle | uploadFile(\ ``int uniqueId``, ``File file``,          |
-| Response``        | ``String ownerName``)                                  |
-+-------------------+--------------------------------------------------------+
++-----------------------------+---------------------------------------------------------------------+
+| Type                        | Method                                                              |
++=============================+=====================================================================+
+| ``ApiEntitySingleResponse`` | uploadFile(\ ``int uniqueId``, ``File file``)                       |
++-----------------------------+---------------------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | uploadFile(\ ``int uniqueId``, ``File file``, ``String ownerName``) |
++-----------------------------+---------------------------------------------------------------------+
 
 AbstractBatchWriterAdapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2474,7 +2278,7 @@ the batch file using the following write methods:
 Once a batch configuration is created, the ApiEntitySingleResponse
 object returns BatchResponseData with a batchId if successful. This
 batchId is used to upload the batch file using the ``uploadFile``
-method. At this point, a successfuly response to the upload will trigger
+method. At this point, a successfully response to the upload will trigger
 the batch. Use the BatchReaderAdapter to poll for the status of the
 batch.
 
@@ -2494,31 +2298,31 @@ Note that the deletes require the Security Label as the ``uniqueId``
 String (P). The create and update requires the full SecurityLabel object
 (T).
 
-+-------------------------------+--------------------------------------------------------+
-| Type                          | *Method*                                               |
-+===============================+========================================================+
-| ``WriteListResponse<T>``      | create(\ ``List<T> itemList``)                         |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | create(\ ``T item``)                                   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | create(\ ``T item``, ``String ownerName``)             |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<P>``      | delete(\ ``List<P> itemIds``)                          |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<P>``      | delete(\ ``List<P> itemIds``, ``String ownerName``)    |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | delete(\ ``P itemId``)                                 |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | delete(\ ``P itemId``, ``String ownerName``)           |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<T>``      | update(\ ``List<T> itemList``)                         |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<T>``      | update(\ ``List<T> itemList``, ``String ownerName``)   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | update(\ ``T item``)                                   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | update(\ ``T item``, ``String ownerName``)             |
-+-------------------------------+--------------------------------------------------------+
++-----------------------------+------------------------------------------------------+
+| Type                        | *Method*                                             |
++=============================+======================================================+
+| ``WriteListResponse<T>``    | create(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``)                        |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``, ``String ownerName``)  |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``)                               |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``, ``String ownerName``)         |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``, ``String ownerName``) |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
 
 TagWriterAdapter
 ~~~~~~~~~~~~~~~~
@@ -2534,31 +2338,31 @@ Below is the standard create methods available to all WriterAdapters.
 Note that the deletes require the Tag Name as the ``uniqueId`` String
 (P). The create and update requires the full Tag object (T).
 
-+-------------------------------+--------------------------------------------------------+
-| Type                          | *Method*                                               |
-+===============================+========================================================+
-| ``WriteListResponse<T>``      | create(\ ``List<T> itemList``)                         |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | create(\ ``T item``)                                   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | create(\ ``T item``, ``String ownerName``)             |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<P>``      | delete(\ ``List<P> itemIds``)                          |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<P>``      | delete(\ ``List<P> itemIds``, ``String ownerName``)    |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | delete(\ ``P itemId``)                                 |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | delete(\ ``P itemId``, ``String ownerName``)           |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<T>``      | update(\ ``List<T> itemList``)                         |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<T>``      | update(\ ``List<T> itemList``, ``String ownerName``)   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | update(\ ``T item``)                                   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | update(\ ``T item``, ``String ownerName``)             |
-+-------------------------------+--------------------------------------------------------+
++-----------------------------+------------------------------------------------------+
+| Type                        | *Method*                                             |
++=============================+======================================================+
+| ``WriteListResponse<T>``    | create(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``)                        |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``, ``String ownerName``)  |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``)                               |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``, ``String ownerName``)         |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``, ``String ownerName``) |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
 
 TaskWriterAdapter
 ~~~~~~~~~~~~~~~~~
@@ -2567,47 +2371,47 @@ The TaskWriterAdapter allows
 
 Below is the standard create methods available to all WriterAdapters.
 
-+-------------------------------+
-| Type                          |
-+===============================+
-| ``WriteListResponse<T>``      |
-+-------------------------------+
-| ``ApiEntitySingleResponse``   |
-+-------------------------------+
-| ``ApiEntitySingleResponse``   |
-+-------------------------------+
-| ``WriteListResponse<P>``      |
-+-------------------------------+
-| ``WriteListResponse<P>``      |
-+-------------------------------+
-| ``ApiEntitySingleResponse``   |
-+-------------------------------+
-| ``ApiEntitySingleResponse``   |
-+-------------------------------+
-| ``WriteListResponse<T>``      |
-+-------------------------------+
-| ``WriteListResponse<T>``      |
-+-------------------------------+
-| ``ApiEntitySingleResponse``   |
-+-------------------------------+
-| ``ApiEntitySingleResponse``   |
-+-------------------------------+
++-----------------------------+------------------------------------------------------+
+| Type                        | Method                                               |
++=============================+======================================================+
+| ``WriteListResponse<T>``    | create(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``)                        |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``, ``String ownerName``)  |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``)                               |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``, ``String ownerName``)         |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``, ``String ownerName``) |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
 
 In addition to the User-specific methods below. Note the delete methods
 require the username while the create methods require the entire User
 object.
 
-+--------------------+------------------------------------------------+
-| Type               | *Method*                                       |
-+====================+================================================+
-| ``UserResponse``   | createAssignee(P uniqueId, User assignee)      |
-+--------------------+------------------------------------------------+
-| ``UserResponse``   | createEscalatee(P uniqueId, User escalatee)    |
-+--------------------+------------------------------------------------+
-| ``UserResponse``   | deleteAssignee(P uniqueId, String userName)    |
-+--------------------+------------------------------------------------+
-| ``UserResponse``   | deleteEscalatee(P uniqueId, String userName)   |
-+--------------------+------------------------------------------------+
++------------------+----------------------------------------------+
+| Type             | *Method*                                     |
++==================+==============================================+
+| ``UserResponse`` | createAssignee(P uniqueId, User assignee)    |
++------------------+----------------------------------------------+
+| ``UserResponse`` | createEscalatee(P uniqueId, User escalatee)  |
++------------------+----------------------------------------------+
+| ``UserResponse`` | deleteAssignee(P uniqueId, String userName)  |
++------------------+----------------------------------------------+
+| ``UserResponse`` | deleteEscalatee(P uniqueId, String userName) |
++------------------+----------------------------------------------+
 
 VictimWriterAdapter
 ~~~~~~~~~~~~~~~~~~~
@@ -2625,31 +2429,31 @@ Note that the deletes require the system-generated VictimAsset ID as the
 ``uniqueId`` Integer (P). The create and update requires the full
 VictimAsset object (T).
 
-+-------------------------------+--------------------------------------------------------+
-| Type                          | *Method*                                               |
-+===============================+========================================================+
-| ``WriteListResponse<T>``      | create(\ ``List<T> itemList``)                         |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | create(\ ``T item``)                                   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | create(\ ``T item``, ``String ownerName``)             |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<P>``      | delete(\ ``List<P> itemIds``)                          |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<P>``      | delete(\ ``List<P> itemIds``, ``String ownerName``)    |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | delete(\ ``P itemId``)                                 |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | delete(\ ``P itemId``, ``String ownerName``)           |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<T>``      | update(\ ``List<T> itemList``)                         |
-+-------------------------------+--------------------------------------------------------+
-| ``WriteListResponse<T>``      | update(\ ``List<T> itemList``, ``String ownerName``)   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | update(\ ``T item``)                                   |
-+-------------------------------+--------------------------------------------------------+
-| ``ApiEntitySingleResponse``   | update(\ ``T item``, ``String ownerName``)             |
-+-------------------------------+--------------------------------------------------------+
++-----------------------------+------------------------------------------------------+
+| Type                        | *Method*                                             |
++=============================+======================================================+
+| ``WriteListResponse<T>``    | create(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | create(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``)                        |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<P>``    | delete(\ ``List<P> itemIds``, ``String ownerName``)  |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``)                               |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | delete(\ ``P itemId``, ``String ownerName``)         |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``)                       |
++-----------------------------+------------------------------------------------------+
+| ``WriteListResponse<T>``    | update(\ ``List<T> itemList``, ``String ownerName``) |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``)                                 |
++-----------------------------+------------------------------------------------------+
+| ``ApiEntitySingleResponse`` | update(\ ``T item``, ``String ownerName``)           |
++-----------------------------+------------------------------------------------------+
 
 Writer Examples
 ~~~~~~~~~~~~~~~

--- a/docs/java/java_sdk.rst
+++ b/docs/java/java_sdk.rst
@@ -272,7 +272,7 @@ Organization must be created.
 |              | resources.                                                  |
 +--------------+-------------------------------------------------------------+
 
-Summary
+**Summary**
 
 This section explained:
 
@@ -1285,7 +1285,7 @@ Tags from our IP address Indicators:
 |       | address is iterated through and printed to the console.           |
 +-------+-------------------------------------------------------------------+
 
-Summary
+**Summary**
 
 This example explained how to:
 
@@ -1585,7 +1585,7 @@ Code Sample
 |        | dumped to the console.                                            |
 +--------+-------------------------------------------------------------------+
 
-Summary
+**Summary**
 
 This example explained how to:
 
@@ -3173,7 +3173,7 @@ Code Sample Description
 |              | dumped to the console.                                      |
 +--------------+-------------------------------------------------------------+
 
-Summary
+**Summary**
 
 The previous two examples explained how to:
 

--- a/docs/java/java_sdk.rst
+++ b/docs/java/java_sdk.rst
@@ -432,50 +432,50 @@ ThreatConnect API. It covers all available resources exposed through the
 ThreatConnect API. The primary classes in the Reader Package, which
 encompass all read functionality from the API, are listed below.
 
-+--------------------------------------+---------------------------------+
-| Class                                | *Description*                   |
-+======================================+=================================+
-| ``ReaderAdapterFactory``             | Primary entry point to          |
-|                                      | instantiate all readers in the  |
-|                                      | Reader Package.                 |
-+--------------------------------------+---------------------------------+
-| ``AbstractGroupReaderAdapter<T exten | Generic Group Reader Abstract   |
-| ds Group>``                          | class. Concrete object          |
-|                                      | available in                    |
-|                                      | ReaderAdapterFactory.           |
-+--------------------------------------+---------------------------------+
-| ``AbstractIndicatorReaderAdapter<T e | Generic Indicator Reader        |
-| xtends Indicator>``                  | Abstract class. Concrete object |
-|                                      | available in                    |
-|                                      | ReaderAdapterFactory.           |
-+--------------------------------------+---------------------------------+
-| ``AbstractReaderAdapter``            | Base Abstract Reader for all    |
-|                                      | Reader Adapters in the Reader   |
-|                                      | Package.                        |
-+--------------------------------------+---------------------------------+
-| ``OwnerReaderAdapter``               | Concrete Reader for             |
-|                                      | Organization owner data.        |
-|                                      | Convenience object available in |
-|                                      | ReaderAdapterFactory.           |
-+--------------------------------------+---------------------------------+
-| ``SecurityLabelReaderAdapter``       | Concrete Reader for             |
-|                                      | SecurityLabel data. Convenience |
-|                                      | object available in             |
-|                                      | ReaderAdapterFactory.           |
-+--------------------------------------+---------------------------------+
-| ``TagReaderAdapter``                 | Concrete Reader for Tag data.   |
-|                                      | Convenience object available in |
-|                                      | ReaderAdapterFactory.           |
-+--------------------------------------+---------------------------------+
-| ``TaskReaderAdapter``                | Concrete Reader for Task data.  |
-|                                      | Convenience object available in |
-|                                      | ReaderAdapterFactory.           |
-+--------------------------------------+---------------------------------+
-| ``VictimReaderAdapter``              | Concrete Reader for Victim      |
-|                                      | data. Convenience object        |
-|                                      | available in                    |
-|                                      | ReaderAdapterFactory.           |
-+--------------------------------------+---------------------------------+
++---------------------------------------------------------+---------------------------------+
+| Class                                                   | *Description*                   |
++=========================================================+=================================+
+| ``ReaderAdapterFactory``                                | Primary entry point to          |
+|                                                         | instantiate all readers in the  |
+|                                                         | Reader Package.                 |
++---------------------------------------------------------+---------------------------------+
+| ``AbstractGroupReaderAdapter<T extends Group>``         | Generic Group Reader Abstract   |
+|                                                         | class. Concrete object          |
+|                                                         | available in                    |
+|                                                         | ReaderAdapterFactory.           |
++---------------------------------------------------------+---------------------------------+
+| ``AbstractIndicatorReaderAdapter<T extends Indicator>`` | Generic Indicator Reader        |
+|                                                         | Abstract class. Concrete object |
+|                                                         | available in                    |
+|                                                         | ReaderAdapterFactory.           |
++---------------------------------------------------------+---------------------------------+
+| ``AbstractReaderAdapter``                               | Base Abstract Reader for all    |
+|                                                         | Reader Adapters in the Reader   |
+|                                                         | Package.                        |
++---------------------------------------------------------+---------------------------------+
+| ``OwnerReaderAdapter``                                  | Concrete Reader for             |
+|                                                         | Organization owner data.        |
+|                                                         | Convenience object available in |
+|                                                         | ReaderAdapterFactory.           |
++---------------------------------------------------------+---------------------------------+
+| ``SecurityLabelReaderAdapter``                          | Concrete Reader for             |
+|                                                         | SecurityLabel data. Convenience |
+|                                                         | object available in             |
+|                                                         | ReaderAdapterFactory.           |
++---------------------------------------------------------+---------------------------------+
+| ``TagReaderAdapter``                                    | Concrete Reader for Tag data.   |
+|                                                         | Convenience object available in |
+|                                                         | ReaderAdapterFactory.           |
++---------------------------------------------------------+---------------------------------+
+| ``TaskReaderAdapter``                                   | Concrete Reader for Task data.  |
+|                                                         | Convenience object available in |
+|                                                         | ReaderAdapterFactory.           |
++---------------------------------------------------------+---------------------------------+
+| ``VictimReaderAdapter``                                 | Concrete Reader for Victim      |
+|                                                         | data. Convenience object        |
+|                                                         | available in                    |
+|                                                         | ReaderAdapterFactory.           |
++---------------------------------------------------------+---------------------------------+
 
 Reader Factory
 ~~~~~~~~~~~~~~
@@ -1051,9 +1051,13 @@ The methods below return owners who have created the Indicator under the uniqueI
 
 The methods below return False Positive counts for the Indicator under the uniqueId.
 
-\|Type\|Method \| -------------------------------------------------------- \|
-``FalsePositive``\ \|getFalsePositive(String uniqueId) \| ``FalsePositive``\ \|getFalsePositive(String uniqueId, String
-ownerName) \|
++-------------------+-----------------------------------------------------+
+| Type              | Method                                            |
++===================+=====================================================+
+| ``FalsePositive`` | getFalsePositive(String uniqueId)                   |
++-------------------+-----------------------------------------------------+
+| ``FalsePositive`` | getFalsePositive(String uniqueId, String ownerName) |
++-------------------+-----------------------------------------------------+
 
 The methods below return Observations and Observation counts for the Indicator under the uniqueId.
 

--- a/docs/java/java_sdk.rst
+++ b/docs/java/java_sdk.rst
@@ -304,25 +304,25 @@ Java app. There is no need to include these libraries in the
 installation zip file. There is also no need to include these libraries
 in the ``configuration`` variable named ``java.classpath``.
 
-+-----------------------------------------------------------------------------------+-----------+
-| Library                                                                           | Version   |
-+===================================================================================+===========+
-| `ThreatConnect SDK <https://github.com/ThreatConnect-Inc/threatconnect-java>`__   | 2.0.0     |
-+-----------------------------------------------------------------------------------+-----------+
-| `HTTP Core <https://hc.apache.org/httpcomponents-core-ga/>`__                     | 4.4.1     |
-+-----------------------------------------------------------------------------------+-----------+
-| `HTTP Client <https://hc.apache.org/httpcomponents-client-ga/>`__                 | 4.4.1     |
-+-----------------------------------------------------------------------------------+-----------+
-| `Commons Logging <http://commons.apache.org/proper/commons-logging/>`__           | 1.2       |
-+-----------------------------------------------------------------------------------+-----------+
-| `Commons Codec <https://commons.apache.org/proper/commons-codec/>`__              | 1.9       |
-+-----------------------------------------------------------------------------------+-----------+
-| `Jackson Core <https://github.com/FasterXML/jackson-core>`__                      | 2.5.3     |
-+-----------------------------------------------------------------------------------+-----------+
-| `Jackson Databind <https://github.com/FasterXML/jackson-databind/>`__             | 2.5.3     |
-+-----------------------------------------------------------------------------------+-----------+
-| `Jackson Annotation <https://github.com/FasterXML/jackson-annotations>`__         | 2.5.0     |
-+-----------------------------------------------------------------------------------+-----------+
++---------------------------------------------------------------------------------+---------+
+| Library                                                                         | Version |
++=================================================================================+=========+
+| `ThreatConnect SDK <https://github.com/ThreatConnect-Inc/threatconnect-java>`__ | 2.0.0   |
++---------------------------------------------------------------------------------+---------+
+| `HTTP Core <https://hc.apache.org/httpcomponents-core-ga/>`__                   | 4.4.1   |
++---------------------------------------------------------------------------------+---------+
+| `HTTP Client <https://hc.apache.org/httpcomponents-client-ga/>`__               | 4.4.1   |
++---------------------------------------------------------------------------------+---------+
+| `Commons Logging <http://commons.apache.org/proper/commons-logging/>`__         | 1.2     |
++---------------------------------------------------------------------------------+---------+
+| `Commons Codec <https://commons.apache.org/proper/commons-codec/>`__            | 1.9     |
++---------------------------------------------------------------------------------+---------+
+| `Jackson Core <https://github.com/FasterXML/jackson-core>`__                    | 2.5.3   |
++---------------------------------------------------------------------------------+---------+
+| `Jackson Databind <https://github.com/FasterXML/jackson-databind/>`__           | 2.5.3   |
++---------------------------------------------------------------------------------+---------+
+| `Jackson Annotation <https://github.com/FasterXML/jackson-annotations>`__       | 2.5.0   |
++---------------------------------------------------------------------------------+---------+
 
 Deployment Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -619,9 +619,7 @@ illustrate the usage of different methods in the ReaderFactory.
 IterableResponse Class
 ~~~~~~~~~~~~~~~~~~~~~~
 
-    Using this iterable, the developer can utilize traditional
-    ``iterator()`` methods to iterate through the results, or, more
-    concisely, the Java for each loop is as follows:
+Using this iterable, the developer can utilize traditional ``iterator()`` methods to iterate through the results, or, more concisely, the Java for each loop is as follows:
 
 .. code:: java
 

--- a/docs/javascript/javascript_sdk.rst
+++ b/docs/javascript/javascript_sdk.rst
@@ -92,13 +92,13 @@ ThreatConnect Object:
 
 **Third-Party Dependencies**
 
-+-------------+-----------+----------------------------------------+
-| Name        | Version   | Link                                   |
-+=============+===========+========================================+
-| jquery      | 2.1.4     | https://jquery.com/                    |
-+-------------+-----------+----------------------------------------+
-| Crypto-JS   | 3.1       | https://code.google.com/p/crypto-js/   |
-+-------------+-----------+----------------------------------------+
++-----------+---------+--------------------------------------+
+| Name      | Version | Link                                 |
++===========+=========+======================================+
+| jquery    | 2.1.4   | https://jquery.com/                  |
++-----------+---------+--------------------------------------+
+| Crypto-JS | 3.1     | https://code.google.com/p/crypto-js/ |
++-----------+---------+--------------------------------------+
 
 **Technical Design**
 
@@ -112,25 +112,25 @@ The JavaScript SDK supports the Resource Types listed below. There is
 also a mechanism to do manual API requests to cover any API calls that
 are not provided with the core functionality.
 
-+-------------------------+------------------------------------+
-| Object                  | Description                        |
-+=========================+====================================+
-| ``groups()``            | Group container object             |
-+-------------------------+------------------------------------+
-| ``indicators()``        | Indicator container object         |
-+-------------------------+------------------------------------+
-| ``indicatorsBatch()``   | Batch Indicator container object   |
-+-------------------------+------------------------------------+
-| ``owners()``            | Owner container object             |
-+-------------------------+------------------------------------+
-| ``securityLabel()``     | Security Label container object    |
-+-------------------------+------------------------------------+
-| ``tags()``              | Tag container object               |
-+-------------------------+------------------------------------+
-| ``tasks()``             | Task container object              |
-+-------------------------+------------------------------------+
-| ``victims()``           | Victim container object            |
-+-------------------------+------------------------------------+
++-----------------------+----------------------------------+
+| Object                | Description                      |
++=======================+==================================+
+| ``groups()``          | Group container object           |
++-----------------------+----------------------------------+
+| ``indicators()``      | Indicator container object       |
++-----------------------+----------------------------------+
+| ``indicatorsBatch()`` | Batch Indicator container object |
++-----------------------+----------------------------------+
+| ``owners()``          | Owner container object           |
++-----------------------+----------------------------------+
+| ``securityLabel()``   | Security Label container object  |
++-----------------------+----------------------------------+
+| ``tags()``            | Tag container object             |
++-----------------------+----------------------------------+
+| ``tasks()``           | Task container object            |
++-----------------------+----------------------------------+
+| ``victims()``         | Victim container object          |
++-----------------------+----------------------------------+
 
 Example JavaScript App
 ----------------------
@@ -322,33 +322,33 @@ the job execution.
 Since all Spaces apps are managed within ThreatConnect, app developers
 should never hard-code ThreatConnect Parameters
 
-+----------------------+-------------------------------------------------------+
-| ThreatConnect        | Description                                           |
-| Parameter            |                                                       |
-+======================+=======================================================+
-| ``tcSpaceElementId`` | The unique space element instance ID for the user who |
-|                      | added this app to their Space. This numeric ID can be |
-|                      | used by the app to store state for the user.          |
-+----------------------+-------------------------------------------------------+
-| ``tcToken``          | Session token to be used by the app to access the     |
-|                      | API. The JavaScript SDK has configuration options for |
-|                      | this parameter.                                       |
-+----------------------+-------------------------------------------------------+
-| ``tcApiPath``        | The path to the API defined in System Settings for    |
-|                      | all apps.                                             |
-+----------------------+-------------------------------------------------------+
-| ``tcType``           | Only relevant for context-aware apps. This field      |
-|                      | corresponds to the runtime.context Attribute defined  |
-|                      | in the install configuration file.                    |
-+----------------------+-------------------------------------------------------+
-| ``tcSelectedItem``   | Only relevant for context-aware apps. This is the     |
-|                      | actual context-item identifier used within            |
-|                      | ThreatConnect. For instance, a Host identifier might  |
-|                      | be: g00gle.com                                        |
-+----------------------+-------------------------------------------------------+
-| ``tcSelectedItemOw   | Only relevant for context-aware apps. This is the     |
-| ner``                | Owner of the context item.                            |
-+----------------------+-------------------------------------------------------+
++-------------------------+-------------------------------------------------------+
+| ThreatConnect           | Description                                           |
+| Parameter               |                                                       |
++=========================+=======================================================+
+| ``tcSpaceElementId``    | The unique space element instance ID for the user who |
+|                         | added this app to their Space. This numeric ID can be |
+|                         | used by the app to store state for the user.          |
++-------------------------+-------------------------------------------------------+
+| ``tcToken``             | Session token to be used by the app to access the     |
+|                         | API. The JavaScript SDK has configuration options for |
+|                         | this parameter.                                       |
++-------------------------+-------------------------------------------------------+
+| ``tcApiPath``           | The path to the API defined in System Settings for    |
+|                         | all apps.                                             |
++-------------------------+-------------------------------------------------------+
+| ``tcType``              | Only relevant for context-aware apps. This field      |
+|                         | corresponds to the runtime.context Attribute defined  |
+|                         | in the install configuration file.                    |
++-------------------------+-------------------------------------------------------+
+| ``tcSelectedItem``      | Only relevant for context-aware apps. This is the     |
+|                         | actual context-item identifier used within            |
+|                         | ThreatConnect. For instance, a Host identifier might  |
+|                         | be: g00gle.com                                        |
++-------------------------+-------------------------------------------------------+
+| ``tcSelectedItemOwner`` | Only relevant for context-aware apps. This is the     |
+|                         | Owner of the context item.                            |
++-------------------------+-------------------------------------------------------+
 
 JavaScript Examples
 
@@ -2493,21 +2493,21 @@ The JavaScript SDK ``requestObject`` provides the ``payload()`` method
 to add any additional query string parameters. This example shows how to
 add filters to a manual request using the ``payload()`` option.
 
-+--------------------------+--------------------------+
-| Query String Parameter   | Helper Method            |
-+==========================+==========================+
-| owner                    | owner()                  |
-+--------------------------+--------------------------+
-| createActivityLog        | createActivityLog()      |
-+--------------------------+--------------------------+
-| resultLimit              | resultLimit()            |
-+--------------------------+--------------------------+
-| resultStart              | resultStart()            |
-+--------------------------+--------------------------+
-| filters                  | manually via payload()   |
-+--------------------------+--------------------------+
-| orParams                 | manually via payload()   |
-+--------------------------+--------------------------+
++------------------------+------------------------+
+| Query String Parameter | Helper Method          |
++========================+========================+
+| owner                  | owner()                |
++------------------------+------------------------+
+| createActivityLog      | createActivityLog()    |
++------------------------+------------------------+
+| resultLimit            | resultLimit()          |
++------------------------+------------------------+
+| resultStart            | resultStart()          |
++------------------------+------------------------+
+| filters                | manually via payload() |
++------------------------+------------------------+
+| orParams               | manually via payload() |
++------------------------+------------------------+
 
 For a full list of query string parameters supported by the
 ThreatConnect API reference the ThreatConnect API User Guide.

--- a/docs/javascript/javascript_sdk.rst
+++ b/docs/javascript/javascript_sdk.rst
@@ -140,14 +140,18 @@ JavaScript SDK for the ThreatConnect API:
 
 .. code:: javascript
 
-    var apiSettings,
-        tcSpaceElementId = getParameterByName('tcSpaceElementId');
+    var apiSettings
 
+    // retrieve Space Element ID (only supported for Spaces applications)
+    var tcSpaceElementId = getParameterByName('tcSpaceElementId');
+
+    // use the Space Element ID if it exists
     if ( tcSpaceElementId ) {
         apiSettings = {
             apiToken: getParameterByName('tcToken'),
             apiUrl: getParameterByName('tcApiPath')
         };
+    // otherwise, use the API settings defined below
     } else {
         apiSettings = {
             apiId: '12345678900987654321',
@@ -156,15 +160,20 @@ JavaScript SDK for the ThreatConnect API:
         };
     }
 
+    // create ThreatConnect object
     var tc = new ThreatConnect(apiSettings);
 
+    // get Owners object
     tc.owners()
+        // if the call finishes successfully, the "done" callback will be run
         .done(function(response) {
             console.log('owner response', response);
         })
+        // if the call does NOT finish successfully, the "error" callback will be run
         .error(function(response) {
             console.log('owner response error', response.error);
         })
+        // retrieve Owners
         .retrieve();
 
 This example illustrates how to write a program using the JavaScript SDK
@@ -173,50 +182,7 @@ pull a collection of all Owners to which the API account being used has
 access. Once retrieved, the Owners objects will be printed to the
 console.
 
-Code Highlights
-
-+--------------------------+-------------------------------------------------+
-| Snippet                  | Description                                     |
-+==========================+=================================================+
-| ``tcSpaceElementId = get | Retrieve Space Element Id (only supported on    |
-| ParameterByNam...``      | Spaces application).                            |
-+--------------------------+-------------------------------------------------+
-| ``apiToken: getParameter | Retrieve Token from Spaces.                     |
-| ByName('tcToken')``      |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``apiUrl: getParameterBy | Retrieve API Path from Spaces.                  |
-| Name('tcApiPath')``      |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``apiId: '12345678900987 | Set API ID when not using Spaces App.           |
-| 654321',``               |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``apiSec: 'aabbccddeeffg | Set API Secret when not using Spaces App.       |
-| ghhiijjkkllmmn...``      |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``apiUrl: 'https://demo. | Set API URL when not using Spaces App.          |
-| threatconnect.com/api``  |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``var tc = new ThreatCon | Get ThreatConnect Object.                       |
-| nect(apiSettings)``      |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``tc.owners()``          | Get Owners object.                              |
-+--------------------------+-------------------------------------------------+
-| ``.done(function(respons | Set "done" callback.                            |
-| e) {``                   |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``console.log('owner res | Console log response.                           |
-| ponse', response)``      |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``.error(function(respon | Set "error" callback.                           |
-| se) {``                  |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``console.log('owner res | Console log any error.                          |
-| ponse error', ...``      |                                                 |
-+--------------------------+-------------------------------------------------+
-| ``.retrieve();``         | Retrieve Owners.                                |
-+--------------------------+-------------------------------------------------+
-
-Summary
+**Summary**
 
 This section explained how to:
 

--- a/docs/rest_api/rest_api_docs.rst
+++ b/docs/rest_api/rest_api_docs.rst
@@ -213,20 +213,18 @@ result limit of items to be returned as HTTP query parameters to the
 request. For example, requesting a result start index of 50 and a result
 limit of 100 will retrieve items 50 to 150.
 
-Table 2 displays the query parameters.
+The table below displays the query parameters.
 
-Table 2 - Query Parameters
-
-+------------------+--------------------------------------------------+---------+
-| HTTP Query       | Description                                      | Default |
-| Parameter        |                                                  |         |
-+==================+==================================================+=========+
-| resultStart\*    | The starting index of the result list that is    | 0       |
-|                  | returned                                         |         |
-+------------------+--------------------------------------------------+---------+
-| resultLimit      | The limit to the number of results to return     | 100     |
-|                  | with the request                                 |         |
-+------------------+--------------------------------------------------+---------+
++---------------+-----------------------------------------------+---------+
+| HTTP Query    | Description                                   | Default |
+| Parameter     |                                               |         |
++===============+===============================================+=========+
+| resultStart\* | The starting index of the result list that is | 0       |
+|               | returned                                      |         |
++---------------+-----------------------------------------------+---------+
+| resultLimit   | The limit to the number of results to return  | 100     |
+|               | with the request                              |         |
++---------------+-----------------------------------------------+---------+
 
 \*Specifying a resultStart other than 0 will omit the resultCount field
 in the return data for performance reasons.
@@ -567,63 +565,63 @@ manually - Importing the Indicator via structured or unstructured import
 - Changing or resetting the Indicator’s "Threat" Rating - Changing the
 Indicator’s Confidence value
 
-Table 3 - Filters
+**Filters**
 
-+--------------------------------+------------+-----------+----------------------------------+
-| Name                           | Data Type  | Operators | DB Field                         |
-+================================+============+===========+==================================+
-| Indicator Common Filters       |            |           |                                  |
-+--------------------------------+------------+-----------+----------------------------------+
-| summary                        | String     | ``= ^``   | indicator.summary                |
-+--------------------------------+------------+-----------+----------------------------------+
-| dateAdded                      | Date       | ``< >``   | indicator.dateAdded              |
-+--------------------------------+------------+-----------+----------------------------------+
-| rating                         | BigDecimal | ``<>``    | indicator.rating                 |
-+--------------------------------+------------+-----------+----------------------------------+
-| confidence                     | Short      | ``=<>``   | indicator.confidence             |
-+--------------------------------+------------+-----------+----------------------------------+
-| threatAssessRating             | Double     | ``<>``    | commonIndicator.rating           |
-+--------------------------------+------------+-----------+----------------------------------+
-| threatAssessConfidence         | Double     | ``<>``    | commonIndicator.confidence       |
-+--------------------------------+------------+-----------+----------------------------------+
-| Address Specific Filters       |            |           |                                  |
-+--------------------------------+------------+-----------+----------------------------------+
-| countryCode                    | String     | ``=``     | ipgeo.countryCode                |
-+--------------------------------+------------+-----------+----------------------------------+
-| organization                   | String     | ``=``     | ipgeo.registeringOrg             |
-+--------------------------------+------------+-----------+----------------------------------+
-| asn                            | Integer    | ``=``     | ipgeo.asn                        |
-+--------------------------------+------------+-----------+----------------------------------+
-| Host Specific Filters          |            |           |                                  |
-+--------------------------------+------------+-----------+----------------------------------+
-| whoisActive                    | Boolean    | ``=``     | Indicator.flag2 on a host record |
-+--------------------------------+------------+-----------+----------------------------------+
-| dnsActive                      | Boolean    | ``=``     | Indicator.flag1 on a host record |
-+--------------------------------+------------+-----------+----------------------------------+
-| Groups Type Filters            |            |           |                                  |
-+--------------------------------+------------+-----------+----------------------------------+
-| name                           | String     | ``= ^``   | bucket.name                      |
-+--------------------------------+------------+-----------+----------------------------------+
-| dateAdded                      | Date       | ``=<>``   | bucket.dateAdded                 |
-+--------------------------------+------------+-----------+----------------------------------+
-| Groups Document Filter         |            |           |                                  |
-+--------------------------------+------------+-----------+----------------------------------+
-| fileType                       | String     | ``=``     | bucketDocument.type              |
-+--------------------------------+------------+-----------+----------------------------------+
-| Security Label Specific Filter |            |           |                                  |
-+--------------------------------+------------+-----------+----------------------------------+
-| name                           | String     | ``= ^``   | securitylabel.name               |
-+--------------------------------+------------+-----------+----------------------------------+
-| Tag Specific Filter            |            |           |                                  |
-+--------------------------------+------------+-----------+----------------------------------+
-| name                           | String     | ``= ^``   | tag.name                         |
-+--------------------------------+------------+-----------+----------------------------------+
-| weight                         | Integer    | ``=<>``   | tag.weight                       |
-+--------------------------------+------------+-----------+----------------------------------+
-| Victim Specific Filter         |            |           |                                  |
-+--------------------------------+------------+-----------+----------------------------------+
-| name                           | String     | ``=  ^``  | victim.name                      |
-+--------------------------------+------------+-----------+----------------------------------+
++------------------------------------+------------+-----------+----------------------------------+
+| Name                               | Data Type  | Operators | DB Field                         |
++====================================+============+===========+==================================+
+| **Indicator Common Filters**       |            |           |                                  |
++------------------------------------+------------+-----------+----------------------------------+
+| summary                            | String     | ``= ^``   | indicator.summary                |
++------------------------------------+------------+-----------+----------------------------------+
+| dateAdded                          | Date       | ``< >``   | indicator.dateAdded              |
++------------------------------------+------------+-----------+----------------------------------+
+| rating                             | BigDecimal | ``<>``    | indicator.rating                 |
++------------------------------------+------------+-----------+----------------------------------+
+| confidence                         | Short      | ``=<>``   | indicator.confidence             |
++------------------------------------+------------+-----------+----------------------------------+
+| threatAssessRating                 | Double     | ``<>``    | commonIndicator.rating           |
++------------------------------------+------------+-----------+----------------------------------+
+| threatAssessConfidence             | Double     | ``<>``    | commonIndicator.confidence       |
++------------------------------------+------------+-----------+----------------------------------+
+| **Address Specific Filters**       |            |           |                                  |
++------------------------------------+------------+-----------+----------------------------------+
+| countryCode                        | String     | ``=``     | ipgeo.countryCode                |
++------------------------------------+------------+-----------+----------------------------------+
+| organization                       | String     | ``=``     | ipgeo.registeringOrg             |
++------------------------------------+------------+-----------+----------------------------------+
+| asn                                | Integer    | ``=``     | ipgeo.asn                        |
++------------------------------------+------------+-----------+----------------------------------+
+| **Host Specific Filters**          |            |           |                                  |
++------------------------------------+------------+-----------+----------------------------------+
+| whoisActive                        | Boolean    | ``=``     | Indicator.flag2 on a host record |
++------------------------------------+------------+-----------+----------------------------------+
+| dnsActive                          | Boolean    | ``=``     | Indicator.flag1 on a host record |
++------------------------------------+------------+-----------+----------------------------------+
+| **Groups Type Filters**            |            |           |                                  |
++------------------------------------+------------+-----------+----------------------------------+
+| name                               | String     | ``= ^``   | bucket.name                      |
++------------------------------------+------------+-----------+----------------------------------+
+| dateAdded                          | Date       | ``=<>``   | bucket.dateAdded                 |
++------------------------------------+------------+-----------+----------------------------------+
+| **Groups Document Filter**         |            |           |                                  |
++------------------------------------+------------+-----------+----------------------------------+
+| fileType                           | String     | ``=``     | bucketDocument.type              |
++------------------------------------+------------+-----------+----------------------------------+
+| **Security Label Specific Filter** |            |           |                                  |
++------------------------------------+------------+-----------+----------------------------------+
+| name                               | String     | ``= ^``   | securitylabel.name               |
++------------------------------------+------------+-----------+----------------------------------+
+| **Tag Specific Filter**            |            |           |                                  |
++------------------------------------+------------+-----------+----------------------------------+
+| name                               | String     | ``= ^``   | tag.name                         |
++------------------------------------+------------+-----------+----------------------------------+
+| weight                             | Integer    | ``=<>``   | tag.weight                       |
++------------------------------------+------------+-----------+----------------------------------+
+| **Victim Specific Filter**         |            |           |                                  |
++------------------------------------+------------+-----------+----------------------------------+
+| name                               | String     | ``=  ^``  | victim.name                      |
++------------------------------------+------------+-----------+----------------------------------+
 
 .. note:: ``<``, ``>``, and ``^`` operators need to be escaped in the url as: ``< %3C``, ``> %3E``, ``^ %5E``.
 
@@ -636,7 +634,7 @@ required or if the specific path supports specifying an Owner. Note that
 if a path does not support the Owner argument, but one is supplied, the
 argument will simply be ignored. Detailed information on each of the
 Resource Types, as well as example responses, are available later in
-this document. Table 3 also references multiple Indicator and Group
+this document. The table above also references multiple Indicator and Group
 types. Currently, these are the supported types for each entity:
 
 Indicators: ``/v2/indicators/``
@@ -650,6 +648,7 @@ Indicators: ``/v2/indicators/``
 Groups: ``/v2/groups/``
 
 -  Adversaries: ``/v2/groups/adversaries/``
+-  Campaigns: ``/v2/groups/campaigns/``
 -  Documents: ``/v2/groups/documents/``
 -  Emails: ``/v2/groups/emails/``
 -  Incidents: ``/v2/groups/incidents/``
@@ -726,23 +725,23 @@ Indicators Resource Type XML Response:
      </Data>
     </indicatorsResponse>
 
-Table 4 - Indicators Resource Type
+**Indicators Resource Type**
 
-+-----------------------------------------------------------+-----------------+-----------------------+
-| Paths                                                     | Owner Allowed   | Pagination Required   |
-+===========================================================+=================+=======================+
-| ``/v2/indicators``                                        | TRUE            | TRUE                  |
-+-----------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/groups/<group type>/<ID>/indicators``               | FALSE           |                       |
-+-----------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/tags/<tag name>/indicators``                        | TRUE            |                       |
-+-----------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/securityLabels/<security label name>/indicators``   | TRUE            |                       |
-+-----------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/indicators``                           | FALSE           |                       |
-+-----------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/tasks/<ID>/indicators``                             | TRUE            |                       |
-+-----------------------------------------------------------+-----------------+-----------------------+
++---------------------------------------------------------+---------------+---------------------+
+| Paths                                                   | Owner Allowed | Pagination Required |
++=========================================================+===============+=====================+
+| ``/v2/indicators``                                      | TRUE          | TRUE                |
++---------------------------------------------------------+---------------+---------------------+
+| ``/v2/groups/<group type>/<ID>/indicators``             | FALSE         |                     |
++---------------------------------------------------------+---------------+---------------------+
+| ``/v2/tags/<tag name>/indicators``                      | TRUE          |                     |
++---------------------------------------------------------+---------------+---------------------+
+| ``/v2/securityLabels/<security label name>/indicators`` | TRUE          |                     |
++---------------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/indicators``                         | FALSE         |                     |
++---------------------------------------------------------+---------------+---------------------+
+| ``/v2/tasks/<ID>/indicators``                           | TRUE          |                     |
++---------------------------------------------------------+---------------+---------------------+
 
 Indicator Types
 ^^^^^^^^^^^^^^^
@@ -1040,23 +1039,23 @@ Hosts Resource Type XML Response:
     </hostsResponse>
 
 A list of Hosts from both the Groups and Tags Service can be retrieved,
-as detailed in Table 4.
+as detailed in the table below.
 
-Table 5 - Hosts Resource Type
+**Hosts Resource Type**
 
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| Paths                                                           | Owner Allowed   | Pagination Required   |
-+=================================================================+=================+=======================+
-| ``/v2/indicators/hosts``                                        | TRUE            | TRUE                  |
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/groups/<group type>/<ID>/indicators/hosts``               | FALSE           |                       |
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/tags/<tag name>/indicators/hosts``                        | TRUE            |                       |
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/securityLabels/<security label name>/indicators/hosts``   | TRUE            |                       |
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/indicators/hosts``                           | FALSE           |                       |
-+-----------------------------------------------------------------+-----------------+-----------------------+
++---------------------------------------------------------------+---------------+---------------------+
+| Paths                                                         | Owner Allowed | Pagination Required |
++===============================================================+===============+=====================+
+| ``/v2/indicators/hosts``                                      | TRUE          | TRUE                |
++---------------------------------------------------------------+---------------+---------------------+
+| ``/v2/groups/<group type>/<ID>/indicators/hosts``             | FALSE         |                     |
++---------------------------------------------------------------+---------------+---------------------+
+| ``/v2/tags/<tag name>/indicators/hosts``                      | TRUE          |                     |
++---------------------------------------------------------------+---------------+---------------------+
+| ``/v2/securityLabels/<security label name>/indicators/hosts`` | TRUE          |                     |
++---------------------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/indicators/hosts``                         | FALSE         |                     |
++---------------------------------------------------------------+---------------+---------------------+
 
 Host Resource Type
 ^^^^^^^^^^^^^^^^^^
@@ -1131,13 +1130,13 @@ The Indicators Service allows for the querying of a specific Host for a
 user’s Organization, as well as any Communities to which a user has
 access.
 
-Table 6 - Host Resource Type
+**Host Resource Type**
 
-+---------------------------------------+-----------------+-----------------------+
-| Paths                                 | Owner Allowed   | Pagination Required   |
-+=======================================+=================+=======================+
-| ``/v2/indicators/hosts/<hostname>``   | TRUE            | FALSE                 |
-+---------------------------------------+-----------------+-----------------------+
++-------------------------------------+---------------+---------------------+
+| Paths                               | Owner Allowed | Pagination Required |
++=====================================+===============+=====================+
+| ``/v2/indicators/hosts/<hostname>`` | TRUE          | FALSE               |
++-------------------------------------+---------------+---------------------+
 
 For each Host, its Attributes, DNS Resolutions, associated Groups, Tags,
 Security Labels, Victims, Victim Assets, and available Owners can also
@@ -1296,23 +1295,23 @@ which a user has access. Both IPv4 and IPv6 address types are supported,
 both with queries and as possible results, in the "ip" field.
 
 A list of Addresses from both the Groups and Tags Service, as detailed
-in Table 6, may also be retrieved.
+in the table below, may also be retrieved.
 
-Table 7 - Addresses Resource Type
+**Addresses Resource Type**
 
-+---------------------------------------------------------------------+-----------------+-----------------------+
-| Paths                                                               | Owner Allowed   | Pagination Required   |
-+=====================================================================+=================+=======================+
-| ``/v2/indicators/addresses``                                        | TRUE            | TRUE                  |
-+---------------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/groups/<group type>/<ID>/indicators/addresses``               | FALSE           |                       |
-+---------------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/tags/<tag name>/indicators/addresses``                        | TRUE            |                       |
-+---------------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/securityLabels/<security label name>/indicators/addresses``   | TRUE            |                       |
-+---------------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/indicators/addresses``                           | FALSE           |                       |
-+---------------------------------------------------------------------+-----------------+-----------------------+
++-------------------------------------------------------------------+---------------+---------------------+
+| Paths                                                             | Owner Allowed | Pagination Required |
++===================================================================+===============+=====================+
+| ``/v2/indicators/addresses``                                      | TRUE          | TRUE                |
++-------------------------------------------------------------------+---------------+---------------------+
+| ``/v2/groups/<group type>/<ID>/indicators/addresses``             | FALSE         |                     |
++-------------------------------------------------------------------+---------------+---------------------+
+| ``/v2/tags/<tag name>/indicators/addresses``                      | TRUE          |                     |
++-------------------------------------------------------------------+---------------+---------------------+
+| ``/v2/securityLabels/<security label name>/indicators/addresses`` | TRUE          |                     |
++-------------------------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/indicators/addresses``                         | FALSE         |                     |
++-------------------------------------------------------------------+---------------+---------------------+
 
 The Indicators Service allows for the querying of a specific Address for
 a user’s Organization, as well as any Communities to which a user has
@@ -1365,13 +1364,13 @@ Address Resource TypeXML Response:
      </Data>
     </addressResponse>
 
-Table 8 - Address Resource Type
+**Address Resource Type**
 
-+------------------------------------------+-----------------+-----------------------+
-| Paths                                    | Owner Allowed   | Pagination Required   |
-+==========================================+=================+=======================+
-| ``/v2/indicators/addresses/<address>``   | TRUE            | FALSE                 |
-+------------------------------------------+-----------------+-----------------------+
++----------------------------------------+---------------+---------------------+
+| Paths                                  | Owner Allowed | Pagination Required |
++========================================+===============+=====================+
+| ``/v2/indicators/addresses/<address>`` | TRUE          | FALSE               |
++----------------------------------------+---------------+---------------------+
 
 For each Address, its Attributes, DNS Resolutions, associated Groups,
 Tags, Security Labels , Victims , Victim Assets , and available Owners
@@ -1557,24 +1556,23 @@ The Indicators Service allows for the querying of a Collection of Files
 for a user’s Organization, as well as any Communities to which a user
 has access.
 
-A list of Files from both the Groups and Tags Service, as detailed in
-Table 8, can also be retrieved.
+A list of Files from both the Groups and Tags Service, as detailed in the table below, can also be retrieved.
 
-Table 9 - Files Resource Type
+**Files Resource Type**
 
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| Paths                                                           | Owner Allowed   | Pagination Required   |
-+=================================================================+=================+=======================+
-| ``/v2/indicators/files``                                        | TRUE            | TRUE                  |
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/groups/<group type>/<ID>/indicators/files``               | FALSE           |                       |
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/tags/<tag name>/indicators/files``                        | TRUE            |                       |
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/securityLabels/<security label name>/indicators/files``   | TRUE            |                       |
-+-----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/indicators/files``                           | FALSE           |                       |
-+-----------------------------------------------------------------+-----------------+-----------------------+
++---------------------------------------------------------------+---------------+---------------------+
+| Paths                                                         | Owner Allowed | Pagination Required |
++===============================================================+===============+=====================+
+| ``/v2/indicators/files``                                      | TRUE          | TRUE                |
++---------------------------------------------------------------+---------------+---------------------+
+| ``/v2/groups/<group type>/<ID>/indicators/files``             | FALSE         |                     |
++---------------------------------------------------------------+---------------+---------------------+
+| ``/v2/tags/<tag name>/indicators/files``                      | TRUE          |                     |
++---------------------------------------------------------------+---------------+---------------------+
+| ``/v2/securityLabels/<security label name>/indicators/files`` | TRUE          |                     |
++---------------------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/indicators/files``                         | FALSE         |                     |
++---------------------------------------------------------------+---------------+---------------------+
 
 The Files Resource Type response format is to the right. Note that with
 support for additional hash types, the Files response format may return
@@ -1637,13 +1635,13 @@ File Resource Type XML Response:
      </Data>
     </fileResponse>
 
-Table 10 - File Resource Type
+**File Resource Type**
 
-+-----------------------------------+-----------------+-----------------------+
-| Paths                             | Owner Allowed   | Pagination Required   |
-+===================================+=================+=======================+
-| ``/v2/indicators/files/<hash>``   | TRUE            | FALSE                 |
-+-----------------------------------+-----------------+-----------------------+
++---------------------------------+---------------+---------------------+
+| Paths                           | Owner Allowed | Pagination Required |
++=================================+===============+=====================+
+| ``/v2/indicators/files/<hash>`` | TRUE          | FALSE               |
++---------------------------------+---------------+---------------------+
 
 The File Resource Type response format is to the right. Note that any
 valid MD5, SHA-1, or SHA-256 hash in the system may be supplied. If
@@ -1684,16 +1682,15 @@ FileOccurrence Resource Type XML Response:
      <Date>2014-11-05T00:00:00Z</Date>
     </FileOccurrence>
 
-Table 11 - FileOccurrence Resource Type
+For each File, its File Occurrences can be retrieved as detailed in the table below.
 
-For each File, its File Occurrences can be retrieved from a separate
-service.
+**FileOccurrence Resource Type**
 
-+---------------------------------------------------+-----------------+-----------------------+
-| Paths                                             | Owner Allowed   | Pagination Required   |
-+===================================================+=================+=======================+
-| ``/v2/indicators/files/<hash>/fileOccurrences``   | TRUE            | FALSE                 |
-+---------------------------------------------------+-----------------+-----------------------+
++-------------------------------------------------+---------------+---------------------+
+| Paths                                           | Owner Allowed | Pagination Required |
++=================================================+===============+=====================+
+| ``/v2/indicators/files/<hash>/fileOccurrences`` | TRUE          | FALSE               |
++-------------------------------------------------+---------------+---------------------+
 
 emailAddresses Resource Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1770,23 +1767,23 @@ Addresses for a user’s Organization, as well as any Communities to which
 a user has access:
 
 A list of Email Addresses from both the Groups and Tags Service, as
-detailed in Table 11, can be retrieved.
+detailed in the table below, can be retrieved.
 
-Table 12 - Email Addresses Resource Type
+**Email Addresses Resource Type**
 
-+--------------------------------------------------------------------------+-----------------+-----------------------+
-| Paths                                                                    | Owner Allowed   | Pagination Required   |
-+==========================================================================+=================+=======================+
-| ``/v2/indicators/emailAddresses``                                        | TRUE            | TRUE                  |
-+--------------------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/groups/<group type>/<ID>/indicators/emailAddresses``               | FALSE           |                       |
-+--------------------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/tags/<tag name>/indicators/emailAddresses``                        | TRUE            |                       |
-+--------------------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/securityLabels/<security label name>/indicators/emailAddresses``   | TRUE            |                       |
-+--------------------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/indicators/emailAddresses``                           | FALSE           |                       |
-+--------------------------------------------------------------------------+-----------------+-----------------------+
++------------------------------------------------------------------------+---------------+---------------------+
+| Paths                                                                  | Owner Allowed | Pagination Required |
++========================================================================+===============+=====================+
+| ``/v2/indicators/emailAddresses``                                      | TRUE          | TRUE                |
++------------------------------------------------------------------------+---------------+---------------------+
+| ``/v2/groups/<group type>/<ID>/indicators/emailAddresses``             | FALSE         |                     |
++------------------------------------------------------------------------+---------------+---------------------+
+| ``/v2/tags/<tag name>/indicators/emailAddresses``                      | TRUE          |                     |
++------------------------------------------------------------------------+---------------+---------------------+
+| ``/v2/securityLabels/<security label name>/indicators/emailAddresses`` | TRUE          |                     |
++------------------------------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/indicators/emailAddresses``                         | FALSE         |                     |
++------------------------------------------------------------------------+---------------+---------------------+
 
 emailAddress Resource Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1853,13 +1850,13 @@ The Indicators Service allows for the querying of a specific Email
 Address for a user’s Organization, as well as any Communities to which a
 user has access:
 
-Table 13 - emailAddress Resource Type
+**emailAddress Resource Type**
 
-+-----------------------------------------------------+-----------------+-----------------------+
-| Paths                                               | Owner Allowed   | Pagination Required   |
-+=====================================================+=================+=======================+
-| ``/v2/indicators/emailAddresses/<email address>``   | TRUE            | FALSE                 |
-+-----------------------------------------------------+-----------------+-----------------------+
++---------------------------------------------------+---------------+---------------------+
+| Paths                                             | Owner Allowed | Pagination Required |
++===================================================+===============+=====================+
+| ``/v2/indicators/emailAddresses/<email address>`` | TRUE          | FALSE               |
++---------------------------------------------------+---------------+---------------------+
 
 For each Email Address, its Attributes, associated Groups, Tags,
 Security Labels , Victims , Victim Assets , and available Owners can be
@@ -1939,24 +1936,23 @@ The Indicators Service allows for the querying of a Collection of URLs
 for a user’s Organization, as well as any Communities to which a user
 has access:
 
-A list of URLs from both the Groups and Tags Service, as detailed in
-Table 13, can be retrieved.
+A list of URLs from both the Groups and Tags Service, as detailed in the table below, can be retrieved.
 
-Table 14 - urls Resource Type
+**urls Resource Type**
 
-+----------------------------------------------------------------+-----------------+-----------------------+
-| Paths                                                          | Owner Allowed   | Pagination Required   |
-+================================================================+=================+=======================+
-| ``/v2/indicators/urls``                                        | TRUE            | TRUE                  |
-+----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/groups/<group type>/<ID>/indicators/urls``               | FALSE           |                       |
-+----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/tags/<tag name>/indicators/urls``                        | TRUE            |                       |
-+----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/securityLabels/<security label name>/indicators/urls``   | TRUE            |                       |
-+----------------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/indicators/urls``                           | FALSE           |                       |
-+----------------------------------------------------------------+-----------------+-----------------------+
++--------------------------------------------------------------+---------------+---------------------+
+| Paths                                                        | Owner Allowed | Pagination Required |
++==============================================================+===============+=====================+
+| ``/v2/indicators/urls``                                      | TRUE          | TRUE                |
++--------------------------------------------------------------+---------------+---------------------+
+| ``/v2/groups/<group type>/<ID>/indicators/urls``             | FALSE         |                     |
++--------------------------------------------------------------+---------------+---------------------+
+| ``/v2/tags/<tag name>/indicators/urls``                      | TRUE          |                     |
++--------------------------------------------------------------+---------------+---------------------+
+| ``/v2/securityLabels/<security label name>/indicators/urls`` | TRUE          |                     |
++--------------------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/indicators/urls``                         | FALSE         |                     |
++--------------------------------------------------------------+---------------+---------------------+
 
 url Resource Type
 ^^^^^^^^^^^^^^^^^
@@ -2023,13 +2019,13 @@ The Indicators Service allows for the querying of a specific URL for a
 user’s Organization, as well as any Communities to which a user has
 access:
 
-Table 15 - URL Resource Type
+**URL Resource Type**
 
-+---------------------------------+-----------------+-----------------------+
-| Paths                           | Owner Allowed   | Pagination Required   |
-+=================================+=================+=======================+
-| ``/v2/indicators/urls/<url>``   | TRUE            | FALSE                 |
-+---------------------------------+-----------------+-----------------------+
++-------------------------------+---------------+---------------------+
+| Paths                         | Owner Allowed | Pagination Required |
++===============================+===============+=====================+
+| ``/v2/indicators/urls/<url>`` | TRUE          | FALSE               |
++-------------------------------+---------------+---------------------+
 
 For each URL, its Attributes, associated Groups, Tags, Security Labels ,
 Victims , Victim Assets , and available Owners can be retrieved.
@@ -2544,10 +2540,9 @@ Generic Groups Resource Type XML Response:
      </Data>
     </groupsResponse>
 
-A list of Groups from both the Indicators and Tags Service, as detailed
-in Table 15, can be retrieved.
+A list of Groups from both the Indicators and Tags Service, as detailed in the table below, can be retrieved.
 
-Table 16 - Groups Resource Type
+**Groups Resource Type**
 
 +--------------------------------------------------------+---------------+---------------------+
 | Paths                                                  | Owner Allowed | Pagination Required |
@@ -2675,10 +2670,9 @@ Incidents Resource Type XML Response:
      </Data>
     </incidentsResponse>
 
-A list of Incidents from both the Indicators and Tags Service, as
-detailed in Table 16, can be retrieved.
+A list of Incidents from both the Indicators and Tags Service, as detailed in the table below, can be retrieved.
 
-Table 17 - Incidents Resource Type
+**Incidents Resource Type**
 
 +------------------------------------------------------------------+---------------+---------------------+
 | Paths                                                            | Owner Allowed | Pagination Required |
@@ -2793,22 +2787,19 @@ Incident Resource Type XML Response Including Incident Status:
      </Data>
     </incidentResponse>
 
-Table 18 - Incident Resource Type
+**Incident Resource Type**
 
-+--------------------------------------------------------+-----------------+-----------------------+
-| Paths                                                  | Owner Allowed   | Pagination Required   |
-+========================================================+=================+=======================+
-| ``/v2/groups/incidents/<ID>``                          | FALSE           | FALSE                 |
-+--------------------------------------------------------+-----------------+-----------------------+
-| ``/v2/groups/incidents/<ID>?includeAdditional=true``   | FALSE           | FALSE                 |
-+--------------------------------------------------------+-----------------+-----------------------+
++------------------------------------------------------+---------------+---------------------+
+| Paths                                                | Owner Allowed | Pagination Required |
++======================================================+===============+=====================+
+| ``/v2/groups/incidents/<ID>``                        | FALSE         | FALSE               |
++------------------------------------------------------+---------------+---------------------+
+| ``/v2/groups/incidents/<ID>?includeAdditional=true`` | FALSE         | FALSE               |
++------------------------------------------------------+---------------+---------------------+
 
-For each Incident, its Attributes, associated Indicators, Security
-Labels, Victims, Victim Assets, and Tags can be retrieved.
+Adding the ‘includeAdditional’ parameter will return the same information as ``/v2/groups/incidents/<ID>``, except that it will also include the Incident’s status.
 
-Adding the ‘includeAdditional’ parameter will return the same
-information as ``/v2/groups/incidents/<ID>``, except that it will also
-include the Incident’s status.
+For each Incident, its Attributes, associated Indicators, Security Labels, Victims, Victim Assets, and Tags can be retrieved.
 
 Documents Resource Type
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -2887,10 +2878,9 @@ The Groups Service allows for the querying of a specific Document for a
 user’s Organization, as well as any Communities to which a user has
 access, using the Document’s unique ID.
 
-A list of Documents from both the Indicators and Tags Service, as
-detailed in Table 18, can be retrieved.
+A list of Documents from both the Indicators and Tags Service, as detailed in the table below, can be retrieved.
 
-Table 19 - Documents Resource Type
+**Documents Resource Type**
 
 +------------------------------------------------------------------+---------------+---------------------+
 | Paths                                                            | Owner Allowed | Pagination Required |
@@ -2959,13 +2949,13 @@ Document Resource Type XML Response:
      </Data>
     </documentResponse>
 
-Table 20 - Document Resource Type
+**Document Resource Type**
 
-+---------------------------------+-----------------+-----------------------+
-| Paths                           | Owner Allowed   | Pagination Required   |
-+=================================+=================+=======================+
-| ``/v2/groups/documents/<ID>``   | FALSE           | FALSE                 |
-+---------------------------------+-----------------+-----------------------+
++-------------------------------+---------------+---------------------+
+| Paths                         | Owner Allowed | Pagination Required |
++===============================+===============+=====================+
+| ``/v2/groups/documents/<ID>`` | FALSE         | FALSE               |
++-------------------------------+---------------+---------------------+
 
 Note that the data has a field named "Status" that denotes if the
 document is still in the process of being uploaded and stored within
@@ -3046,10 +3036,9 @@ Threats Resource Type XML Response:
      </Data>
     </threatsResponse>
 
-A list of Threats from both the Indicators and Tags Service, as detailed
-in Table 20, can be retrieved.
+A list of Threats from both the Indicators and Tags Service, as detailed in the table below, can be retrieved.
 
-Table 21 - Threats Resource Type
+**Threats Resource Type**
 
 +----------------------------------------------------------------+---------------+---------------------+
 | Paths                                                          | Owner Allowed | Pagination Required |
@@ -3116,13 +3105,13 @@ Threat Resource Type XML Response:
      </Data>
     </threatResponse>
 
-Table 22 - Threat Resource Type
+**Threat Resource Type**
 
-+-------------------------------+-----------------+-----------------------+
-| Paths                         | Owner Allowed   | Pagination Required   |
-+===============================+=================+=======================+
-| ``/v2/groups/threats/<ID>``   | FALSE           | FALSE                 |
-+-------------------------------+-----------------+-----------------------+
++-----------------------------+---------------+---------------------+
+| Paths                       | Owner Allowed | Pagination Required |
++=============================+===============+=====================+
+| ``/v2/groups/threats/<ID>`` | FALSE         | FALSE               |
++-----------------------------+---------------+---------------------+
 
 For each Threat, its Attributes, associated Indicators, Security Labels,
 Victims, Victim Assets, and Tags can be retrieved.
@@ -3204,10 +3193,9 @@ The Groups Service allows for the querying of a Collection of
 Adversaries for both a user’s Organization, as well as any Communities
 to which a user has access.
 
-A list of Adversaries from both the Indicators and Tags Service, as
-detailed in Table 22, can be retrieved.
+A list of Adversaries from both the Indicators and Tags Service, as detailed in the table below, can be retrieved.
 
-Table 23 - Adversaries Resource Type
+**Adversaries Resource Type**
 
 +--------------------------------------------------------------------+---------------+---------------------+
 | Paths                                                              | Owner Allowed | Pagination Required |
@@ -3274,13 +3262,13 @@ Adversary Resource Type XML Response:
      </Data>
     </adversaryResponse>
 
-Table 24 - Adversary Resource Type
+**Adversary Resource Type**
 
-+-----------------------------------+-----------------+-----------------------+
-| Paths                             | Owner Allowed   | Pagination Required   |
-+===================================+=================+=======================+
-| ``/v2/groups/adversaries/<ID>``   | FALSE           | FALSE                 |
-+-----------------------------------+-----------------+-----------------------+
++---------------------------------+---------------+---------------------+
+| Paths                           | Owner Allowed | Pagination Required |
++=================================+===============+=====================+
+| ``/v2/groups/adversaries/<ID>`` | FALSE         | FALSE               |
++---------------------------------+---------------+---------------------+
 
 For each Adversary, its Attributes, associated Indicators, Security
 Labels, Victims, Victim Assets, and Tags can be retrieved.
@@ -3348,10 +3336,9 @@ The Groups Service allows for the querying of a Collection of Emails for
 a user’s Organization, as well as any Communities to which a user has
 access.
 
-A list of Emails from both the Indicators and Tags Service, as detailed
-in Table 24, can be retrieved.
+A list of Emails from both the Indicators and Tags Service, as detailed in the table below, can be retrieved.
 
-Table 25 - Email Resource Type
+**Email Resource Type**
 
 +---------------------------------------------------------------+---------------+---------------------+
 | Paths                                                         | Owner Allowed | Pagination Required |
@@ -3435,13 +3422,13 @@ Email Resource Type XML Response:
      </Data>
     </emailResponse>
 
-Table 26 - Email Resource Type
+**Email Resource Type**
 
-+------------------------------+-----------------+-----------------------+
-| Paths                        | Owner Allowed   | Pagination Required   |
-+==============================+=================+=======================+
-| ``/v2/groups/emails/<ID>``   | FALSE           | FALSE                 |
-+------------------------------+-----------------+-----------------------+
++----------------------------+---------------+---------------------+
+| Paths                      | Owner Allowed | Pagination Required |
++============================+===============+=====================+
+| ``/v2/groups/emails/<ID>`` | FALSE         | FALSE               |
++----------------------------+---------------+---------------------+
 
 Note that the "to" field may be empty if the field was not supplied when
 the email was uploaded.
@@ -3530,10 +3517,9 @@ The Groups Service allows for the querying of a Collection of Signatures
 for a user’s Organization, as well as any Communities to which a user
 has access.
 
-A list of Signatures from both the Indicators and Tags service, as
-detailed in Table 26, can be retrieved.
+A list of Signatures from both the Indicators and Tags service, as detailed in the table below, can be retrieved.
 
-Table 27 - Signatures Resource Type
+**Signatures Resource Type**
 
 +-------------------------------------------------------------------+---------------+---------------------+
 | Paths                                                             | Owner Allowed | Pagination Required |
@@ -3610,13 +3596,13 @@ Signature Resource Type XML Response:
      </Data>
     </signatureResponse>
 
-Table 28 - Signature Resource Type
+**Signature Resource Type**
 
-+----------------------------------+-----------------+-----------------------+
-| Paths                            | Owner Allowed   | Pagination Required   |
-+==================================+=================+=======================+
-| ``/v2/groups/signatures/<ID>``   | FALSE           | FALSE                 |
-+----------------------------------+-----------------+-----------------------+
++--------------------------------+---------------+---------------------+
+| Paths                          | Owner Allowed | Pagination Required |
++================================+===============+=====================+
+| ``/v2/groups/signatures/<ID>`` | FALSE         | FALSE               |
++--------------------------------+---------------+---------------------+
 
 For each Signature, the Signature content can be downloaded, and the
 response format will mirror the content of the Signature upload.
@@ -3688,10 +3674,9 @@ They are always with another item, such as a Host or a Threat. To
 retrieve a list of Attributes, append the Attributes path onto a
 specific Indicator or Group.
 
-A list of Attributes from both the Indicators and Groups Services, as
-detailed in Table 29, can be retrieved.
+A list of Attributes from both the Indicators and Groups Services, as detailed in the table below, can be retrieved.
 
-Table 29 - Attributes Resource Type
+**Attributes Resource Type**
 
 +------------------------------------------------------------+---------------+---------------------+
 | Paths                                                      | Owner Allowed | Pagination Required |
@@ -3962,8 +3947,7 @@ tagged, as well as the Indicators or Groups of a specific Tag for a
 user’s Organization, as well as any Communities to which a user has
 access, can be found with the Tag Service.
 
-A list of Tags from both the Indicators and Groups Services, as detailed
-in Table 30, can be retrieved.
+A list of Tags from both the Indicators and Groups Services can be retrieved as detailed in the table in the next section.
 
 Tags Resource Type
 ^^^^^^^^^^^^^^^^^^
@@ -4011,7 +3995,7 @@ Tags Resource Type XML Response:
      </Data>
     </tagsResponse>
 
-Table 30 - Tags Resource Type
+**Tags Resource Type**
 
 +------------------------------------------------------+---------------+---------------------+
 | Paths                                                | Owner Allowed | Pagination Required |
@@ -4058,13 +4042,13 @@ Tag Resource Type XML Response:
      </Data>
     </tagResponse>
 
-Table 31 - Tag Resource Type
+**Tag Resource Type**
 
-+---------------------------+-----------------+-----------------------+
-| Paths                     | Owner Allowed   | Pagination Required   |
-+===========================+=================+=======================+
-| ``/v2/tags/<tag name>``   | TRUE            | FALSE                 |
-+---------------------------+-----------------+-----------------------+
++-------------------------+---------------+---------------------+
+| Paths                   | Owner Allowed | Pagination Required |
++=========================+===============+=====================+
+| ``/v2/tags/<tag name>`` | TRUE          | FALSE               |
++-------------------------+---------------+---------------------+
 
 For each Tag, its associated Indicators and Groups can be found.
 
@@ -4120,32 +4104,28 @@ SecurityLabels Resource Type XML Response:
      </Data>
     </securityLabelsResponse>
 
-A list of Security Labels from the Indicator, Group, and Task Services,
-as detailed in Table 31, can be retrieved.
+A list of Security Labels from the Indicator, Group, and Task Services, as detailed in the table below, can be retrieved.
 
-Table 32 - SecurityLabels Resource Type
+**SecurityLabels Resource Type**
 
-+-----------------------------------------------------+---------+------------+
-| Paths                                               | Owner   | Pagination |
-|                                                     | Allowed | Required   |
-+=====================================================+=========+============+
-| ``/v2/securityLabels``                              | TRUE    | TRUE       |
-+-----------------------------------------------------+---------+------------+
-| ``/v2/indicators/<indicator type>/<indicator>/secur | TRUE    |            |
-| ityLabels``                                         |         |            |
-+-----------------------------------------------------+---------+------------+
-| ``/v2/groups/<group type>/<ID>/securityLabels``     | FALSE   |            |
-+-----------------------------------------------------+---------+------------+
-| ``/v2/indicators/<indicator type>/<indicator>/attri | TRUE    |            |
-| butes/<ID>/securityLabels``                         |         |            |
-+-----------------------------------------------------+---------+------------+
-| ``/v2/groups/<group type>/<ID>/attributes/<ID>/     | FALSE   |            |
-| securityLabels``                                    |         |            |
-+-----------------------------------------------------+---------+------------+
-| ``/v2/tasks/<ID>/securityLabels``                   | TRUE    |            |
-+-----------------------------------------------------+---------+------------+
-| ``/v2/tasks/<ID>/attributes/<ID>/securityLabels``   | TRUE    |            |
-+-----------------------------------------------------+---------+------------+
++--------------------------------------------------------------------------------+---------+------------+
+| Paths                                                                          | Owner   | Pagination |
+|                                                                                | Allowed | Required   |
++================================================================================+=========+============+
+| ``/v2/securityLabels``                                                         | TRUE    | TRUE       |
++--------------------------------------------------------------------------------+---------+------------+
+| ``/v2/indicators/<indicator type>/<indicator>/securityLabels``                 | TRUE    |            |
++--------------------------------------------------------------------------------+---------+------------+
+| ``/v2/groups/<group type>/<ID>/securityLabels``                                | FALSE   |            |
++--------------------------------------------------------------------------------+---------+------------+
+| ``/v2/indicators/<indicator type>/<indicator>/attributes/<ID>/securityLabels`` | TRUE    |            |
++--------------------------------------------------------------------------------+---------+------------+
+| ``/v2/groups/<group type>/<ID>/attributes/<ID>/securityLabels``                | FALSE   |            |
++--------------------------------------------------------------------------------+---------+------------+
+| ``/v2/tasks/<ID>/securityLabels``                                              | TRUE    |            |
++--------------------------------------------------------------------------------+---------+------------+
+| ``/v2/tasks/<ID>/attributes/<ID>/securityLabels``                              | TRUE    |            |
++--------------------------------------------------------------------------------+---------+------------+
 
 The SecurityLabels Service allows for the querying of a specific
 Security Label for a user’s Organization, as well as any Communities to
@@ -4180,13 +4160,13 @@ SecurityLabel Resource Type XML Response:
      </Data>
     </securityLabelResponse>
 
-Table 33 - SecurityLabel Resource Type
+**SecurityLabel Resource Type**
 
-+------------------------------------------------+-----------------+-----------------------+
-| Paths                                          | Owner Allowed   | Pagination Required   |
-+================================================+=================+=======================+
-| ``/v2/securityLabels/<security label name>``   | TRUE            | TRUE                  |
-+------------------------------------------------+-----------------+-----------------------+
++----------------------------------------------+---------------+---------------------+
+| Paths                                        | Owner Allowed | Pagination Required |
++==============================================+===============+=====================+
+| ``/v2/securityLabels/<security label name>`` | TRUE          | TRUE                |
++----------------------------------------------+---------------+---------------------+
 
 For each SecurityLabel, its associated Indicators and Groups can be
 found.
@@ -4359,8 +4339,7 @@ Victims Resource Type XML Response:
      <statusCode>OK</statusCode>
     </victimsResponse>
 
-A list of Tasks from both the Indicators and Groups Services, as
-detailed in Table 34, can be retrieved.
+A list of Victims from both the Indicators and Groups Services, as detailed in the table below, can be retrieved.
 
 +---------------------------------------------------------+---------------+---------------------+
 | Paths                                                   | Owner Allowed | Pagination Required |
@@ -4439,10 +4418,9 @@ Victims Resource Type XML Response:
      <statusCode>OK</statusCode>
     </victimsResponse>
 
-A list of Victims from both the Indicators and Groups Services, as
-detailed in Table 34, can be retrieved.
+A list of Victims from both the Indicators and Groups Services, as detailed in the table below, can be retrieved.
 
-Table 34 - Victim List Resource Type
+**Victim List Resource Type**
 
 +---------------------------------------------------------+---------------+---------------------+
 | Paths                                                   | Owner Allowed | Pagination Required |
@@ -4502,13 +4480,13 @@ Victim Resource Type XML Response:
      <statusCode>OK</statusCode>
     </victimResponse>
 
-Table 35 - Victim Resource Type
+**Victim Resource Type**
 
-+------------------------+-----------------+-----------------------+
-| Paths                  | Owner Allowed   | Pagination Required   |
-+========================+=================+=======================+
-| ``/v2/victims/<ID>``   | FALSE           | FALSE                 |
-+------------------------+-----------------+-----------------------+
++----------------------+---------------+---------------------+
+| Paths                | Owner Allowed | Pagination Required |
++======================+===============+=====================+
+| ``/v2/victims/<ID>`` | FALSE         | FALSE               |
++----------------------+---------------+---------------------+
 
 For each Victim, its Attributes, associated Groups, Indicators, Tags,
 and available Owners can be retrieved.
@@ -4736,7 +4714,7 @@ Victim Assets can also be found by querying the victimAssets Collection.
 The victimAssets Collection will return all Assets attached to a
 specified Victim ID.
 
-Table 36 - VictimAssets Resource Type
+**VictimAssets Resource Type**
 
 +--------------------------------------------------------------+---------------+---------------------+
 | Paths                                                        | Owner Allowed | Pagination Required |
@@ -4748,33 +4726,23 @@ Table 36 - VictimAssets Resource Type
 | ``/v2/indicators/<indicator type>/<indicator>/victimAssets`` | TRUE          | FALSE               |
 +--------------------------------------------------------------+---------------+---------------------+
 
-As Table 37 displays, each specific type of Victim Asset can be queried.
+As displayed in the table below, each specific type of Victim Asset can be queried.
 
-Table 37
+**VictimAsset Types**
 
-+-----------------------------------------------------+-----------------+-----------------------+
-| PathsVictim Asset Type                              | Owner Allowed   | Pagination Required   |
-+=====================================================+=================+=======================+
-| ``/v2/victims/<ID>/victimAssets/emailAddresses``    | FALSE           | FALSE                 |
-+-----------------------------------------------------+-----------------+-----------------------+
-| emailAddress                                        |                 |                       |
-+-----------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/victimAssets/networkAccounts``   | FALSE           | FALSE                 |
-+-----------------------------------------------------+-----------------+-----------------------+
-| networkAccount                                      |                 |                       |
-+-----------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/victimAssets/phoneNumbers``      | FALSE           | FALSE                 |
-+-----------------------------------------------------+-----------------+-----------------------+
-| phoneType                                           |                 |                       |
-+-----------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/victimAssets/socialNetworks``    | FALSE           | FALSE                 |
-+-----------------------------------------------------+-----------------+-----------------------+
-| socialNetwork                                       |                 |                       |
-+-----------------------------------------------------+-----------------+-----------------------+
-| ``/v2/victims/<ID>/victimAssets/webSites``          | FALSE           | FALSE                 |
-+-----------------------------------------------------+-----------------+-----------------------+
-| WebSite                                             |                 |                       |
-+-----------------------------------------------------+-----------------+-----------------------+
++---------------------------------------------------+---------------+---------------------+
+| PathsVictim Asset Type                            | Owner Allowed | Pagination Required |
++===================================================+===============+=====================+
+| ``/v2/victims/<ID>/victimAssets/emailAddresses``  | FALSE         | FALSE               |
++---------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/victimAssets/networkAccounts`` | FALSE         | FALSE               |
++---------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/victimAssets/phoneNumbers``    | FALSE         | FALSE               |
++---------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/victimAssets/socialNetworks``  | FALSE         | FALSE               |
++---------------------------------------------------+---------------+---------------------+
+| ``/v2/victims/<ID>/victimAssets/webSites``        | FALSE         | FALSE               |
++---------------------------------------------------+---------------+---------------------+
 
 Sample query and response for emailAddress
 
@@ -5008,54 +4976,52 @@ Sample results for ``urls`` query
 The V2 API will allow for the programmatic creation of Indicators by
 issuing POST requests with valid bodies to the appropriate resources.
 
-Likewise, Table 38 illustrates valid fields for inclusion in the body of
+Likewise, the table below illustrates valid fields for inclusion in the body of
 the POST request when creating an Indicator.
 
-Table 38
-
-+------------------+----------------+------------+
-| Indicator Type   | Valid Fields   | Required   |
-+==================+================+============+
-| addresses        | ip             | TRUE       |
-+------------------+----------------+------------+
-|                  | rating         | FALSE      |
-+------------------+----------------+------------+
-|                  | confidence     | FALSE      |
-+------------------+----------------+------------+
-| emailAddresses   | address        | TRUE       |
-+------------------+----------------+------------+
-|                  | rating         | FALSE      |
-+------------------+----------------+------------+
-|                  | confidence     | FALSE      |
-+------------------+----------------+------------+
-| files            | md5            | TRUE\*     |
-+------------------+----------------+------------+
-|                  | sha1           | TRUE\*     |
-+------------------+----------------+------------+
-|                  | sha256         | TRUE\*     |
-+------------------+----------------+------------+
-|                  | size           | FALSE      |
-+------------------+----------------+------------+
-|                  | rating         | FALSE      |
-+------------------+----------------+------------+
-|                  | confidence     | FALSE      |
-+------------------+----------------+------------+
-| hosts            | hostName       | TRUE       |
-+------------------+----------------+------------+
-|                  | dnsActive      | FALSE      |
-+------------------+----------------+------------+
-|                  | whoisActive    | FALSE      |
-+------------------+----------------+------------+
-|                  | rating         | FALSE      |
-+------------------+----------------+------------+
-|                  | confidence     | FALSE      |
-+------------------+----------------+------------+
-| urls             | text           | TRUE       |
-+------------------+----------------+------------+
-|                  | rating         | FALSE      |
-+------------------+----------------+------------+
-|                  | confidence     | FALSE      |
-+------------------+----------------+------------+
++----------------+--------------+----------+
+| Indicator Type | Valid Fields | Required |
++================+==============+==========+
+| addresses      | ip           | TRUE     |
++----------------+--------------+----------+
+|                | rating       | FALSE    |
++----------------+--------------+----------+
+|                | confidence   | FALSE    |
++----------------+--------------+----------+
+| emailAddresses | address      | TRUE     |
++----------------+--------------+----------+
+|                | rating       | FALSE    |
++----------------+--------------+----------+
+|                | confidence   | FALSE    |
++----------------+--------------+----------+
+| files          | md5          | TRUE\*   |
++----------------+--------------+----------+
+|                | sha1         | TRUE\*   |
++----------------+--------------+----------+
+|                | sha256       | TRUE\*   |
++----------------+--------------+----------+
+|                | size         | FALSE    |
++----------------+--------------+----------+
+|                | rating       | FALSE    |
++----------------+--------------+----------+
+|                | confidence   | FALSE    |
++----------------+--------------+----------+
+| hosts          | hostName     | TRUE     |
++----------------+--------------+----------+
+|                | dnsActive    | FALSE    |
++----------------+--------------+----------+
+|                | whoisActive  | FALSE    |
++----------------+--------------+----------+
+|                | rating       | FALSE    |
++----------------+--------------+----------+
+|                | confidence   | FALSE    |
++----------------+--------------+----------+
+| urls           | text         | TRUE     |
++----------------+--------------+----------+
+|                | rating       | FALSE    |
++----------------+--------------+----------+
+|                | confidence   | FALSE    |
++----------------+--------------+----------+
 
 \*Files are required to be submitted with at least one valid hash.
 
@@ -5248,54 +5214,51 @@ future reference.
 If created successfully, the V2 API will respond with a response
 detailing the Group created.
 
-Table 39 details the acceptable fields and values when creating a Group.
+The table below details the acceptable fields and values when creating a Group.
 
-Table 39
++-------------+--------------+----------+
+| Group Type  | Valid Fields | Required |
++=============+==============+==========+
+| adversaries | name         | TRUE     |
++-------------+--------------+----------+
+| documents   | fileName     | TRUE     |
++-------------+--------------+----------+
+|             | name         | TRUE     |
++-------------+--------------+----------+
+|             | malware      | FALSE    |
++-------------+--------------+----------+
+|             | password     | FALSE    |
++-------------+--------------+----------+
+| emails      | name         | TRUE     |
++-------------+--------------+----------+
+|             | to           | FALSE    |
++-------------+--------------+----------+
+|             | from         | FALSE    |
++-------------+--------------+----------+
+|             | subject      | TRUE     |
++-------------+--------------+----------+
+|             | header       | TRUE     |
++-------------+--------------+----------+
+|             | body         | TRUE     |
++-------------+--------------+----------+
+| incidents   | name         | TRUE     |
++-------------+--------------+----------+
+|             | eventDate    | TRUE     |
++-------------+--------------+----------+
+| threats     | name         | TRUE     |
++-------------+--------------+----------+
+| signatures  | name         | TRUE     |
++-------------+--------------+----------+
+|             | fileName     | TRUE     |
++-------------+--------------+----------+
+|             | fileType\*   | TRUE     |
++-------------+--------------+----------+
+|             | fileText\*\* | TRUE     |
++-------------+--------------+----------+
 
-+---------------+----------------+------------+
-| Group Type    | Valid Fields   | Required   |
-+===============+================+============+
-| adversaries   | name           | TRUE       |
-+---------------+----------------+------------+
-| documents     | fileName       | TRUE       |
-+---------------+----------------+------------+
-|               | name           | TRUE       |
-+---------------+----------------+------------+
-|               | malware        | FALSE      |
-+---------------+----------------+------------+
-|               | password       | FALSE      |
-+---------------+----------------+------------+
-| emails        | name           | TRUE       |
-+---------------+----------------+------------+
-|               | to             | FALSE      |
-+---------------+----------------+------------+
-|               | from           | FALSE      |
-+---------------+----------------+------------+
-|               | subject        | TRUE       |
-+---------------+----------------+------------+
-|               | header         | TRUE       |
-+---------------+----------------+------------+
-|               | body           | TRUE       |
-+---------------+----------------+------------+
-| incidents     | name           | TRUE       |
-+---------------+----------------+------------+
-|               | eventDate      | TRUE       |
-+---------------+----------------+------------+
-| threats       | name           | TRUE       |
-+---------------+----------------+------------+
-| signatures    | name           | TRUE       |
-+---------------+----------------+------------+
-|               | fileName       | TRUE       |
-+---------------+----------------+------------+
-|               | fileType\*     | TRUE       |
-+---------------+----------------+------------+
-|               | fileText\*\*   | TRUE       |
-+---------------+----------------+------------+
+\*The valid values for a Signature’s fileType field are: {Snort ® , Suricata, YARA, ClamAV ® , OpenIOC, CybOX™, Bro, Regex}.
 
-\*The valid values for a Signature’s fileType field are: {Snort ® ,
-Suricata, YARA, ClamAV ® , OpenIOC, CybOX™, Bro, Regex}. \*\*A
-Signature’s fileText field contains the Signature itself, which must be
-properly escaped and encoded when submitting for creation or updating.
+\*\*A Signature’s fileText field contains the Signature itself, which must be properly escaped and encoded when submitting for creation or updating.
 
 Documents
 ^^^^^^^^^
@@ -5773,11 +5736,7 @@ importing large amounts of data.
 
 .. note:: Document Storage is required to use the Batch API.
 
-The Batch Create resource creates a batch entry in the system. No batch
-processing is triggered until the batch input file is uploaded. Table 40
-displays the fields required for the Batch Create message.
-
-Table 40
+The Batch Create resource creates a batch entry in the system. No batch processing is triggered until the batch input file is uploaded. The table below displays the fields required for the Batch Create message.
 
 +---------------------+-----------------+-------------------------------------------------------------------------------------------------------------------+
 | BatchConfig Message | Values          | Description                                                                                                       |
@@ -5825,25 +5784,25 @@ Batch Indicator Input File Format
 The batch upload feature expects to ingest a JSON file consisting of a
 list of dictionaries
 
-+-----------------------+------------------------+-------------+
-| Field                 | Data type              | Required?   |
-+=======================+========================+=============+
-| ``rating``            | integer                | Required    |
-+-----------------------+------------------------+-------------+
-| ``confidence``        | float                  | Required    |
-+-----------------------+------------------------+-------------+
-| ``description``       | string                 | Required    |
-+-----------------------+------------------------+-------------+
-| ``summary``           | string                 | Required    |
-+-----------------------+------------------------+-------------+
-| ``type``              | string                 | Required    |
-+-----------------------+------------------------+-------------+
-| ``tag``               | list of dictionaries   | Optional    |
-+-----------------------+------------------------+-------------+
-| ``attribute``         | list of dictionaries   | Optional    |
-+-----------------------+------------------------+-------------+
-| ``associatedGroup``   | list of integers       | Optional    |
-+-----------------------+------------------------+-------------+
++---------------------+----------------------+-----------+
+| Field               | Data type            | Required? |
++=====================+======================+===========+
+| ``rating``          | integer              | Required  |
++---------------------+----------------------+-----------+
+| ``confidence``      | float                | Required  |
++---------------------+----------------------+-----------+
+| ``description``     | string               | Required  |
++---------------------+----------------------+-----------+
+| ``summary``         | string               | Required  |
++---------------------+----------------------+-----------+
+| ``type``            | string               | Required  |
++---------------------+----------------------+-----------+
+| ``tag``             | list of dictionaries | Optional  |
++---------------------+----------------------+-----------+
+| ``attribute``       | list of dictionaries | Optional  |
++---------------------+----------------------+-----------+
+| ``associatedGroup`` | list of integers     | Optional  |
++---------------------+----------------------+-----------+
 
 Supported ``type`` values for Indicators:
 
@@ -5887,41 +5846,41 @@ Responses
 ~~~~~~~~~
 
 The API will return appropriate HTTP response codes with a description
-in the message field as detailed in Table 40. This can be helpful when
+in the message field as detailed in the table below. This can be helpful when
 troubleshooting queries.
 
-Table 41
+**HTTP Response Codes**
 
-+----------------+-----------------------------------------------------------+
-| HTTP Response  | Explanation                                               |
-| Code           |                                                           |
-+================+===========================================================+
-| 200 - Success  | Successful execution of a request.                        |
-+----------------+-----------------------------------------------------------+
-| 201 - Created  | The query successfully created the specified entity.      |
-+----------------+-----------------------------------------------------------+
-| 400 - Bad      | Status returned if the request was not properly           |
-| Request        | formatted. The message included with the response will    |
-|                | include details.                                          |
-+----------------+-----------------------------------------------------------+
-| 401 -          | Returned if a user does not have access to the specified  |
-| Unauthorized   | resource or the method attempted on a resource.           |
-+----------------+-----------------------------------------------------------+
-| 403 -          | Returned when specifying an Owner to which the user does  |
-| Forbidden      | do not have access, or does not exist.                    |
-+----------------+-----------------------------------------------------------+
-| 403 - Bad      | This Indicator is included in a system-wide exclusion     |
-| Request        | list.                                                     |
-+----------------+-----------------------------------------------------------+
-| 404 - Not      | The service or resource specified in the path does not    |
-| Found          | exist.                                                    |
-+----------------+-----------------------------------------------------------+
-| 500 - Internal | An unknown internal error                                 |
-| Server Error   |                                                           |
-+----------------+-----------------------------------------------------------+
-| 503 - Service  | The Instance of ThreatConnect is not licensed to enable   |
-| Unavailable    | the API.                                                  |
-+----------------+-----------------------------------------------------------+
++----------------+----------------------------------------------------------+
+| HTTP Response  | Explanation                                              |
+| Code           |                                                          |
++================+==========================================================+
+| 200 - Success  | Successful execution of a request.                       |
++----------------+----------------------------------------------------------+
+| 201 - Created  | The query successfully created the specified entity.     |
++----------------+----------------------------------------------------------+
+| 400 - Bad      | Status returned if the request was not properly          |
+| Request        | formatted. The message included with the response will   |
+|                | include details.                                         |
++----------------+----------------------------------------------------------+
+| 401 -          | Returned if a user does not have access to the specified |
+| Unauthorized   | resource or the method attempted on a resource.          |
++----------------+----------------------------------------------------------+
+| 403 -          | Returned when specifying an Owner to which the user does |
+| Forbidden      | do not have access, or does not exist.                   |
++----------------+----------------------------------------------------------+
+| 403 - Bad      | This Indicator is included in a system-wide exclusion    |
+| Request        | list.                                                    |
++----------------+----------------------------------------------------------+
+| 404 - Not      | The service or resource specified in the path does not   |
+| Found          | exist.                                                   |
++----------------+----------------------------------------------------------+
+| 500 - Internal | An unknown internal error                                |
+| Server Error   |                                                          |
++----------------+----------------------------------------------------------+
+| 503 - Service  | The Instance of ThreatConnect is not licensed to enable  |
+| Unavailable    | the API.                                                 |
++----------------+----------------------------------------------------------+
 
 Putting Everything Together
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rest_api/rest_api_docs.rst
+++ b/docs/rest_api/rest_api_docs.rst
@@ -4731,7 +4731,7 @@ As displayed in the table below, each specific type of Victim Asset can be queri
 **VictimAsset Types**
 
 +---------------------------------------------------+---------------+---------------------+
-| PathsVictim Asset Type                            | Owner Allowed | Pagination Required |
+| Paths                                             | Owner Allowed | Pagination Required |
 +===================================================+===============+=====================+
 | ``/v2/victims/<ID>/victimAssets/emailAddresses``  | FALSE         | FALSE               |
 +---------------------------------------------------+---------------+---------------------+


### PR DESCRIPTION
This is a major update in which almost all of the tables broken in the initial transition to .rst files have been fixed. Note to self: the following command is very helpful as it converts markdown to rst and will only wrap tables and content at 120 characters: 

`pandoc -f markdown  -t rst -o ./new_docs.rst ./old_docs.md --wrap=auto --columns=120`.